### PR TITLE
Improve RRT collision checking and speed up loco smoothing

### DIFF
--- a/loco_planner/include/loco_planner/impl/loco_impl.h
+++ b/loco_planner/include/loco_planner/impl/loco_impl.h
@@ -596,8 +596,8 @@ double Loco<N>::computeCollisionCostAndGradient(
 
     // Select a time.
     for (t = 0.0; t < segment_times[i]; t += dt) {
-      mav_trajectory_generation::timing::Timer coll_cost_crap_timer(
-          "loco/coll_cost_crap");
+      mav_trajectory_generation::timing::Timer coll_cost_sample_timer(
+          "loco/coll_cost_sample");
 
       // T is the vector for just THIS SEGMENT.
       getTVector(t, &T_seg);
@@ -633,7 +633,7 @@ double Loco<N>::computeCollisionCostAndGradient(
         continue;
       }
 
-      coll_cost_crap_timer.Stop();
+      coll_cost_sample_timer.Stop();
 
       // Okay figure out the cost and gradient of the potential map at this
       // point.

--- a/loco_planner/include/loco_planner/impl/loco_impl.h
+++ b/loco_planner/include/loco_planner/impl/loco_impl.h
@@ -534,6 +534,8 @@ double Loco<N>::computeDerivativeCostAndGradient(
 template <int N>
 double Loco<N>::computeCollisionCostAndGradient(
     std::vector<Eigen::VectorXd>* gradients) const {
+  mav_trajectory_generation::timing::Timer coll_cost_prep_timer(
+      "loco/coll_cost_prep");
   // Unpack into d_f, d_ps.
   // Get d_p and d_f vector for all axes.
   std::vector<Eigen::VectorXd> d_p_vec;
@@ -578,23 +580,29 @@ double Loco<N>::computeCollisionCostAndGradient(
   double J_c = 0;
   std::vector<Eigen::VectorXd> grad_c(K_, Eigen::VectorXd::Zero(num_free_));
 
+  coll_cost_prep_timer.Stop();
+
   Eigen::VectorXd last_position(K_);
   last_position.setZero();
   // int is "integral" in this case, not "integer."
   double time_int = -1.0;
   double distance_int = 0;
   double t = 0.0;
+
+  Eigen::VectorXd T(num_segments * N);
+  Eigen::VectorXd T_seg(N);
   for (int i = 0; i < num_segments; ++i) {
+    T.setZero();
+
     // Select a time.
-    // std::cout << "Starting segment " << i << std::endl;
     for (t = 0.0; t < segment_times[i]; t += dt) {
+      mav_trajectory_generation::timing::Timer coll_cost_crap_timer(
+          "loco/coll_cost_crap");
+
       // T is the vector for just THIS SEGMENT.
-      Eigen::VectorXd T_seg(N);
       getTVector(t, &T_seg);
 
       // Now fill this in for ALL segments.
-      Eigen::VectorXd T(num_segments * N);
-      T.setZero();
       T.segment(i * N, N) = T_seg;
 
       // Calculate the position per axis. Also calculate velocity so we don't
@@ -611,7 +619,7 @@ double Loco<N>::computeCollisionCostAndGradient(
       }
 
       // Now calculate the distance integral.
-      if (time_int < 0) {
+      if (time_int < 0.0) {
         // Skip this entry if it's the first one.
         time_int = 0.0;
         last_position = position;
@@ -625,13 +633,15 @@ double Loco<N>::computeCollisionCostAndGradient(
         continue;
       }
 
+      coll_cost_crap_timer.Stop();
+
       // Okay figure out the cost and gradient of the potential map at this
       // point.
       Eigen::VectorXd d_c_d_f(K_);
 
       mav_trajectory_generation::timing::Timer timer_map_lookup(
           "loco/map_lookup");
-      double c = 0;
+      double c = 0.0;
       if (gradients != nullptr) {
         c = computePotentialCostAndGradient(position, &d_c_d_f);
       } else {
@@ -643,9 +653,12 @@ double Loco<N>::computeCollisionCostAndGradient(
 
       J_c += cost;
 
+      mav_trajectory_generation::timing::Timer coll_cost_grad_timer(
+          "loco/coll_cost_grad");
+
       if (gradients != nullptr) {
         // Gotta make sure the norm is non-zero, since we divide by it later.
-        if (velocity.norm() > 1e-6) {
+        if (velocity.norm() > 1e-6 && (cost > 0.0 || d_c_d_f.norm() > 0.0)) {
           // Now calculate the gradient per axis.
           for (int k = 0; k < K_; ++k) {
             Eigen::VectorXd grad_c_k =
@@ -659,6 +672,8 @@ double Loco<N>::computeCollisionCostAndGradient(
           }
         }
       }
+
+      coll_cost_grad_timer.Stop();
 
       // Clear the numeric integrals.
       distance_int = 0.0;

--- a/mav_path_smoothing/include/mav_path_smoothing/loco_smoother.h
+++ b/mav_path_smoothing/include/mav_path_smoothing/loco_smoother.h
@@ -9,6 +9,10 @@ namespace mav_planning {
 
 class LocoSmoother : public PolynomialSmoother {
  public:
+  typedef std::function<double(const Eigen::Vector3d& position,
+                               Eigen::Vector3d* gradient)>
+      DistanceAndGradientFunctionType;
+
   LocoSmoother();
   virtual ~LocoSmoother() {}
 
@@ -44,15 +48,36 @@ class LocoSmoother : public PolynomialSmoother {
   bool getAddWaypoints() const { return add_waypoints_; }
   void setAddWaypoints(bool add_waypoints) { add_waypoints_ = add_waypoints; }
 
+  // Use a function to get gradient.
+  void setDistanceAndGradientFunction(
+      const DistanceAndGradientFunctionType& function) {
+    distance_and_gradient_function_ = function;
+  }
+
  protected:
-void resampleWaypointsFromVisibilityGraph(
-    const mav_msgs::EigenTrajectoryPoint::Vector& waypoints,
-    mav_msgs::EigenTrajectoryPoint::Vector* waypoints_out) const;
+  double getMapDistanceAndGradient(const Eigen::VectorXd& position,
+                                   Eigen::VectorXd* gradient) const {
+    CHECK(distance_and_gradient_function_);
+    CHECK_EQ(position.size(), 3);
+    if (gradient == nullptr) {
+      return distance_and_gradient_function_(position, nullptr);
+    }
+    Eigen::Vector3d gradient_3d;
+    double distance = distance_and_gradient_function_(position, &gradient_3d);
+    *gradient = gradient_3d;
+    return distance;
+  }
+
+  void resampleWaypointsFromVisibilityGraph(
+      const mav_msgs::EigenTrajectoryPoint::Vector& waypoints,
+      mav_msgs::EigenTrajectoryPoint::Vector* waypoints_out) const;
 
   bool resample_trajectory_;
   bool resample_visibility_;
   int num_segments_;
   bool add_waypoints_;
+
+  DistanceAndGradientFunctionType distance_and_gradient_function_;
 };
 
 }  // namespace mav_planning

--- a/mav_path_smoothing/src/loco_smoother.cpp
+++ b/mav_path_smoothing/src/loco_smoother.cpp
@@ -59,7 +59,13 @@ bool LocoSmoother::getTrajectoryBetweenWaypoints(
 
   loco.setRobotRadius(constraints_.robot_radius);
   loco.setMapResolution(min_col_check_resolution_);
-  loco.setDistanceFunction(map_distance_func_);
+  if (distance_and_gradient_function_) {
+    loco.setDistanceAndGradientFunction(
+        std::bind(&LocoSmoother::getMapDistanceAndGradient, this,
+                  std::placeholders::_1, std::placeholders::_2));
+  } else {
+    loco.setDistanceFunction(map_distance_func_);
+  }
 
   if (resample_trajectory_) {
     loco.setupFromTrajectoryAndResample(traj_initial, num_segments_);
@@ -93,7 +99,13 @@ bool LocoSmoother::getTrajectoryBetweenTwoPoints(
 
   loco.setRobotRadius(constraints_.robot_radius);
   loco.setMapResolution(min_col_check_resolution_);
-  loco.setDistanceFunction(map_distance_func_);
+  if (distance_and_gradient_function_) {
+    loco.setDistanceAndGradientFunction(
+        std::bind(&LocoSmoother::getMapDistanceAndGradient, this,
+                  std::placeholders::_1, std::placeholders::_2));
+  } else {
+    loco.setDistanceFunction(map_distance_func_);
+  }
 
   double total_time = mav_trajectory_generation::computeTimeVelocityRamp(
       start.position_W, goal.position_W, constraints_.v_max,

--- a/mav_path_smoothing/src/loco_smoother.cpp
+++ b/mav_path_smoothing/src/loco_smoother.cpp
@@ -91,6 +91,8 @@ bool LocoSmoother::getTrajectoryBetweenTwoPoints(
     const mav_msgs::EigenTrajectoryPoint& start,
     const mav_msgs::EigenTrajectoryPoint& goal,
     mav_trajectory_generation::Trajectory* trajectory) const {
+  mav_trajectory_generation::timing::Timer loco_timer("smoothing/poly_loco");
+
   CHECK_NOTNULL(trajectory);
   constexpr int N = 10;
   constexpr int D = 3;

--- a/mav_planning_benchmark/include/mav_planning_benchmark/global_planning_benchmark.h
+++ b/mav_planning_benchmark/include/mav_planning_benchmark/global_planning_benchmark.h
@@ -57,9 +57,12 @@ class GlobalPlanningBenchmark {
   void setupPlanners();
   bool selectRandomStartAndGoal(double minimum_distance, Eigen::Vector3d* start,
                                 Eigen::Vector3d* goal) const;
+
   double getMapDistance(const Eigen::Vector3d& position) const;
   double getMapDistanceWithoutInterpolation(
       const Eigen::Vector3d& position) const;
+  double getMapDistanceAndGradient(const Eigen::Vector3d& position,
+                                   Eigen::Vector3d* gradient) const;
 
   // Evaluate what we've got here.
   void fillInPathResults(const mav_msgs::EigenTrajectoryPointVector& path,

--- a/mav_planning_benchmark/launch/global_planning_benchmark.launch
+++ b/mav_planning_benchmark/launch/global_planning_benchmark.launch
@@ -2,7 +2,7 @@
   <arg name="base_path" default="/home/helen/data/jfr_2018/shed/voxblox/" />
   <arg name="esdf_name" default="stereo_esdf_0.10.voxblox" />
   <arg name="sparse_graph_name" default="stereo_sparse_graph_0.10.voxblox" />
-  <arg name="results_name" default="stereo_results_27_09_2018.csv" />
+  <arg name="results_name" default="stereo_results_11_10_2018a.csv" />
 
   <arg name="frame_id" default="map" />
 

--- a/mav_planning_benchmark/launch/global_planning_benchmark.launch
+++ b/mav_planning_benchmark/launch/global_planning_benchmark.launch
@@ -2,7 +2,7 @@
   <arg name="base_path" default="/home/helen/data/jfr_2018/shed/voxblox/" />
   <arg name="esdf_name" default="stereo_esdf_0.10.voxblox" />
   <arg name="sparse_graph_name" default="stereo_sparse_graph_0.10.voxblox" />
-  <arg name="results_name" default="stereo_results_11_10_2018a.csv" />
+  <arg name="results_name" default="stereo_results_11_10_2018b.csv" />
 
   <arg name="frame_id" default="map" />
 

--- a/mav_planning_benchmark/launch/global_planning_benchmark.launch
+++ b/mav_planning_benchmark/launch/global_planning_benchmark.launch
@@ -2,7 +2,7 @@
   <arg name="base_path" default="/home/helen/data/jfr_2018/shed/voxblox/" />
   <arg name="esdf_name" default="stereo_esdf_0.10.voxblox" />
   <arg name="sparse_graph_name" default="stereo_sparse_graph_0.10.voxblox" />
-  <arg name="results_name" default="stereo_results_11_10_2018b.csv" />
+  <arg name="results_name" default="stereo_results_12_10_2018c.csv" />
 
   <arg name="frame_id" default="map" />
 

--- a/mav_planning_benchmark/src/global_planning_benchmark.cpp
+++ b/mav_planning_benchmark/src/global_planning_benchmark.cpp
@@ -313,7 +313,7 @@ double GlobalPlanningBenchmark::getMapDistance(
     const Eigen::Vector3d& position) const {
   CHECK(esdf_server_);
   double distance = 0.0;
-  const bool kInterpolate = true;
+  const bool kInterpolate = false;
   if (!esdf_server_->getEsdfMapPtr()->getDistanceAtPosition(
           position, kInterpolate, &distance)) {
     return 0.0;

--- a/mav_planning_benchmark/src/global_planning_benchmark.cpp
+++ b/mav_planning_benchmark/src/global_planning_benchmark.cpp
@@ -161,8 +161,9 @@ void GlobalPlanningBenchmark::setupPlanners() {
   // Loco smoother!
   loco_smoother_.setParametersFromRos(nh_private_);
   loco_smoother_.setMinCollisionCheckResolution(voxel_size);
-  loco_smoother_.setMapDistanceCallback(std::bind(
-      &GlobalPlanningBenchmark::getMapDistance, this, std::placeholders::_1));
+  loco_smoother_.setDistanceAndGradientFunction(
+      std::bind(&GlobalPlanningBenchmark::getMapDistanceAndGradient, this,
+                std::placeholders::_1, std::placeholders::_2));
   loco_smoother_.setOptimizeTime(true);
   loco_smoother_.setResampleTrajectory(true);
   loco_smoother_.setResampleVisibility(true);
@@ -316,6 +317,18 @@ double GlobalPlanningBenchmark::getMapDistance(
   const bool kInterpolate = false;
   if (!esdf_server_->getEsdfMapPtr()->getDistanceAtPosition(
           position, kInterpolate, &distance)) {
+    return 0.0;
+  }
+  return distance;
+}
+
+double GlobalPlanningBenchmark::getMapDistanceAndGradient(
+    const Eigen::Vector3d& position, Eigen::Vector3d* gradient) const {
+  CHECK(esdf_server_);
+  double distance = 0.0;
+  const bool kInterpolate = false;
+  if (!esdf_server_->getEsdfMapPtr()->getDistanceAndGradientAtPosition(
+          position, kInterpolate, &distance, gradient)) {
     return 0.0;
   }
   return distance;

--- a/mav_planning_benchmark/src/global_planning_benchmark_node.cpp
+++ b/mav_planning_benchmark/src/global_planning_benchmark_node.cpp
@@ -14,7 +14,7 @@ int main(int argc, char** argv) {
   ROS_INFO("Initialized global planning benchmark node.");
 
   int num_trials = 100;
-  std::string base_path, esdf_name, sparse_graph_name , results_name;
+  std::string base_path, esdf_name, sparse_graph_name, results_name;
   nh_private.param("base_path", base_path, base_path);
   nh_private.param("esdf_name", esdf_name, esdf_name);
   nh_private.param("sparse_graph_name", sparse_graph_name, sparse_graph_name);
@@ -24,6 +24,10 @@ int main(int argc, char** argv) {
   node.loadMap(base_path, esdf_name, sparse_graph_name);
   node.runBenchmark(num_trials);
   node.outputResults(base_path + "/" + results_name);
+
+  ROS_INFO_STREAM("All timings: "
+                  << std::endl
+                  << mav_trajectory_generation::timing::Timing::Print());
 
   ros::spin();
   return 0;

--- a/voxblox_rrt_planner/include/voxblox_rrt_planner/ompl/ompl_voxblox.h
+++ b/voxblox_rrt_planner/include/voxblox_rrt_planner/ompl/ompl_voxblox.h
@@ -217,30 +217,6 @@ class VoxbloxMotionValidator : public base::MotionValidator {
         return false;
       }
     }
-    /*
-    Eigen::Vector3d direction = (goal - start).normalized();
-    double total_distance = (goal - start).norm();
-
-    for (double travelled_distance = 0.0; travelled_distance < total_distance;
-         travelled_distance += voxel_size) {
-      Eigen::Vector3d pos = start + travelled_distance * direction;
-      bool collision = validity_checker_->checkCollisionWithRobot(pos);
-
-      if (collision) {
-        if (last_valid.first != nullptr) {
-          ompl::base::ScopedState<ompl::mav::StateSpace> last_valid_state(
-              si_->getStateSpace());
-          last_valid_state->values[0] = pos.x();
-          last_valid_state->values[1] = pos.y();
-          last_valid_state->values[2] = pos.z();
-
-          si_->copyState(last_valid.first, last_valid_state.get());
-        }
-
-        last_valid.second = travelled_distance / total_distance;
-        return false;
-      }
-    } */
 
     return true;
   }

--- a/voxblox_rrt_planner/include/voxblox_rrt_planner/ompl/ompl_voxblox.h
+++ b/voxblox_rrt_planner/include/voxblox_rrt_planner/ompl/ompl_voxblox.h
@@ -3,8 +3,9 @@
 
 #include <ompl/base/StateValidityChecker.h>
 
-#include <voxblox/core/tsdf_map.h>
 #include <voxblox/core/esdf_map.h>
+#include <voxblox/core/tsdf_map.h>
+#include <voxblox/integrator/integrator_utils.h>
 #include <voxblox/utils/planning_utils.h>
 
 #include "voxblox_rrt_planner/ompl/ompl_types.h"
@@ -39,6 +40,11 @@ class VoxbloxValidityChecker : public base::StateValidityChecker {
   // Returns whether there is a collision: true if yes, false if not.
   virtual bool checkCollisionWithRobot(
       const Eigen::Vector3d& robot_position) const = 0;
+
+  virtual bool checkCollisionWithRobotAtVoxel(
+      const voxblox::GlobalIndex& global_index) const {
+    return checkCollisionWithRobot(global_index.cast<double>() * voxel_size_);
+  }
 
   float voxel_size() const { return voxel_size_; }
 
@@ -124,7 +130,7 @@ class EsdfVoxbloxValidityChecker
   virtual bool checkCollisionWithRobot(
       const Eigen::Vector3d& robot_position) const {
     voxblox::Point robot_point = robot_position.cast<voxblox::FloatingPoint>();
-    constexpr bool interpolate = true;
+    constexpr bool interpolate = false;
     voxblox::FloatingPoint distance;
     bool success = interpolator_.getDistance(
         robot_position.cast<voxblox::FloatingPoint>(), &distance, interpolate);
@@ -132,7 +138,17 @@ class EsdfVoxbloxValidityChecker
       return true;
     }
 
-    return robot_radius_ > distance;
+    return robot_radius_ >= distance;
+  }
+
+  virtual bool checkCollisionWithRobotAtVoxel(
+      const voxblox::GlobalIndex& global_index) const {
+    voxblox::EsdfVoxel* voxel = layer_->getVoxelPtrByGlobalIndex(global_index);
+
+    if (voxel == nullptr) {
+      return true;
+    }
+    return robot_radius_ >= voxel->distance;
   }
 
  protected:
@@ -167,6 +183,41 @@ class VoxbloxMotionValidator : public base::MotionValidator {
     Eigen::Vector3d start = omplToEigen(s1);
     Eigen::Vector3d goal = omplToEigen(s2);
     double voxel_size = validity_checker_->voxel_size();
+
+    voxblox::Point start_scaled, goal_scaled;
+    voxblox::AlignedVector<voxblox::GlobalIndex> indices;
+
+    // Convert the start and goal to global voxel coordinates.
+    // Actually very simple -- just divide by voxel size.
+    start_scaled = start.cast<voxblox::FloatingPoint>() / voxel_size;
+    goal_scaled = goal.cast<voxblox::FloatingPoint>() / voxel_size;
+
+    voxblox::castRay(start_scaled, goal_scaled, &indices);
+
+    for (size_t i = 0; i < indices.size(); i++) {
+      const voxblox::GlobalIndex& global_index = indices[i];
+
+
+      Eigen::Vector3d pos = global_index.cast<double>() * voxel_size;
+      bool collision =
+          validity_checker_->checkCollisionWithRobotAtVoxel(global_index);
+
+      if (collision) {
+        if (last_valid.first != nullptr) {
+          ompl::base::ScopedState<ompl::mav::StateSpace> last_valid_state(
+              si_->getStateSpace());
+          last_valid_state->values[0] = pos.x();
+          last_valid_state->values[1] = pos.y();
+          last_valid_state->values[2] = pos.z();
+
+          si_->copyState(last_valid.first, last_valid_state.get());
+        }
+
+        last_valid.second = static_cast<double>(i / indices.size());
+        return false;
+      }
+    }
+    /*
     Eigen::Vector3d direction = (goal - start).normalized();
     double total_distance = (goal - start).norm();
 
@@ -189,7 +240,7 @@ class VoxbloxMotionValidator : public base::MotionValidator {
         last_valid.second = travelled_distance / total_distance;
         return false;
       }
-    }
+    } */
 
     return true;
   }

--- a/voxblox_skeleton/launch/skeletonize_map.launch
+++ b/voxblox_skeleton/launch/skeletonize_map.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="base_path" default="/home/helen/data/jfr_2018/shed/voxblox/" />
+  <arg name="base_path" default="/home/helen/data/jfr_2018/machine_hall/voxblox/" />
   <arg name="input_map_name" default="rs_esdf_0.10.voxblox" />
   <arg name="output_map_name" default="rs_skeleton_0.10.voxblox" />
   <arg name="sparse_graph_name" default="rs_sparse_graph_0.10.voxblox" />
@@ -11,13 +11,13 @@
 
   <node name="voxblox_skeletonizer" pkg="voxblox_skeleton" type="skeletonizer" output="screen" clear_params="true" args="-v=1">
     <param name="input_filepath" value="$(arg voxblox_path)" />
-    <param name="output_filepath" value="$(arg output_path)" />
-    <param name="sparse_graph_filepath" value="$(arg sparse_graph_path)" />
+    <!--<param name="output_filepath" value="$(arg output_path)" />
+    <param name="sparse_graph_filepath" value="$(arg sparse_graph_path)" /> -->
     <param name="generate_by_layer_neighbors" value="false" />
     <!-- If using full euclidean: 0.78 (45 degrees) -->
     <!-- If using quasi-Euclidean: 1.57 (90 degrees) -->
     <param name="min_separation_angle" value="0.78" />
-    <param name="update_esdf" value="false" />
+    <param name="update_esdf" value="true" />
     <param name="min_gvd_distance" value="0.5" />
     <param name="tsdf_voxel_size" value="0.1" />
     <param name="esdf_max_distance_m" value="5.0" />

--- a/voxblox_skeleton/launch/skeletonize_map.launch
+++ b/voxblox_skeleton/launch/skeletonize_map.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="base_path" default="/home/helen/data/jfr_2018/machine_hall/voxblox/" />
+  <arg name="base_path" default="/home/helen/data/jfr_2018/shed/voxblox/" />
   <arg name="input_map_name" default="rs_esdf_0.10.voxblox" />
   <arg name="output_map_name" default="rs_skeleton_0.10.voxblox" />
   <arg name="sparse_graph_name" default="rs_sparse_graph_0.10.voxblox" />
@@ -11,13 +11,13 @@
 
   <node name="voxblox_skeletonizer" pkg="voxblox_skeleton" type="skeletonizer" output="screen" clear_params="true" args="-v=1">
     <param name="input_filepath" value="$(arg voxblox_path)" />
-    <!--<param name="output_filepath" value="$(arg output_path)" />
-    <param name="sparse_graph_filepath" value="$(arg sparse_graph_path)" /> -->
+    <param name="output_filepath" value="$(arg output_path)" />
+    <param name="sparse_graph_filepath" value="$(arg sparse_graph_path)" />
     <param name="generate_by_layer_neighbors" value="false" />
     <!-- If using full euclidean: 0.78 (45 degrees) -->
     <!-- If using quasi-Euclidean: 1.57 (90 degrees) -->
     <param name="min_separation_angle" value="0.78" />
-    <param name="update_esdf" value="true" />
+    <param name="update_esdf" value="false" />
     <param name="min_gvd_distance" value="0.5" />
     <param name="tsdf_voxel_size" value="0.1" />
     <param name="esdf_max_distance_m" value="5.0" />


### PR DESCRIPTION
RRT collision checking now does raycasting instead of just line traversal.
Collision checking no longer does interpolation to be more consistent between different collision checks.
Loco smoothing sped up considerably in the collision cost calculation, though there is still much more to do...