### PR TITLE
Local benchmark, voxblox loco planner, mav local planner, gazebo sim

### DIFF
--- a/loco_planner/include/loco_planner/impl/loco_impl.h
+++ b/loco_planner/include/loco_planner/impl/loco_impl.h
@@ -312,12 +312,12 @@ void Loco<N>::solveProblemCeres() {
   std::vector<Eigen::VectorXd> d_p_vec;
   poly_opt_.getFreeConstraints(&d_p_vec);
 
-  double* x0 = new double[num_free_ * K_];
+  std::vector<double> parameters(num_free_ * K_);
 
   int i = 0;
   for (int k = 0; k < K_; ++k) {
     for (int j = 0; j < num_free_; ++j) {
-      x0[i] = d_p_vec[k](j);
+      parameters[i] = d_p_vec[k](j);
       ++i;
     }
   }
@@ -334,7 +334,7 @@ void Loco<N>::solveProblemCeres() {
   ceres::GradientProblemSolver::Summary summary;
 
   // Fire up CERES!
-  ceres::Solve(options, problem, x0, &summary);
+  ceres::Solve(options, problem, parameters.data(), &summary);
 
   if (config_.verbose) {
     std::cout << summary.FullReport() << "\n";
@@ -344,7 +344,7 @@ void Loco<N>::solveProblemCeres() {
   i = 0;
   for (int k = 0; k < K_; ++k) {
     for (int j = 0; j < num_free_; ++j) {
-      d_p_vec[k](j) = x0[i];
+      d_p_vec[k](j) = parameters[i];
       ++i;
     }
   }
@@ -910,6 +910,7 @@ template <int N>
 bool Loco<N>::NestedCeresFunction::Evaluate(const double* parameters,
                                             double* cost,
                                             double* gradient) const {
+  CHECK_NOTNULL(parent_);
   // Step 1: allocate all the necessary Eigen vectors.
   std::vector<Eigen::VectorXd> d_p(K_, Eigen::VectorXd::Zero(num_free_));
   std::vector<Eigen::VectorXd> grad_vec(K_, Eigen::VectorXd::Zero(num_free_));

--- a/loco_planner/include/loco_planner/impl/loco_impl.h
+++ b/loco_planner/include/loco_planner/impl/loco_impl.h
@@ -327,10 +327,9 @@ void Loco<N>::solveProblemCeres() {
 
   ceres::GradientProblemSolver::Options options;
   options.line_search_direction_type = ceres::BFGS;
+  options.logging_type = ceres::SILENT;
+  options.minimizer_progress_to_stdout = false;
 
-  if (config_.verbose) {
-    options.minimizer_progress_to_stdout = true;
-  }
   options.line_search_interpolation_type = ceres::BISECTION;
   ceres::GradientProblemSolver::Summary summary;
 

--- a/mav_local_planner/CMakeLists.txt
+++ b/mav_local_planner/CMakeLists.txt
@@ -16,10 +16,10 @@ cs_add_library(${PROJECT_NAME}
 ############
 # BINARIES #
 ############
-#cs_add_executable(voxblox_rrt_planner_node
-#  src/voxblox_rrt_planner_node.cpp
-#)
-#target_link_libraries(voxblox_rrt_planner_node ${PROJECT_NAME})
+cs_add_executable(mav_local_planner_node
+  src/mav_local_planner_node.cpp
+)
+target_link_libraries(mav_local_planner_node ${PROJECT_NAME})
 
 ##########
 # EXPORT #

--- a/mav_local_planner/CMakeLists.txt
+++ b/mav_local_planner/CMakeLists.txt
@@ -4,7 +4,7 @@ project(mav_local_planner)
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
-add_definitions(-std=c++11)
+add_definitions(-std=c++11 -Wall)
 
 #############
 # LIBRARIES #

--- a/mav_local_planner/CMakeLists.txt
+++ b/mav_local_planner/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(mav_local_planner)
+
+find_package(catkin_simple REQUIRED)
+catkin_simple(ALL_DEPS_REQUIRED)
+
+add_definitions(-std=c++11)
+
+#############
+# LIBRARIES #
+#############
+cs_add_library(${PROJECT_NAME}
+  src/mav_local_planner.cpp
+)
+
+############
+# BINARIES #
+############
+#cs_add_executable(voxblox_rrt_planner_node
+#  src/voxblox_rrt_planner_node.cpp
+#)
+#target_link_libraries(voxblox_rrt_planner_node ${PROJECT_NAME})
+
+##########
+# EXPORT #
+##########
+cs_install()
+cs_export()

--- a/mav_local_planner/include/mav_local_planner/mav_local_planner.h
+++ b/mav_local_planner/include/mav_local_planner/mav_local_planner.h
@@ -1,6 +1,21 @@
 #ifndef MAV_LOCAL_PLANNER_MAV_LOCAL_PLANNER_H_
 #define MAV_LOCAL_PLANNER_MAV_LOCAL_PLANNER_H_
 
+#include <ros/ros.h>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <geometry_msgs/PoseArray.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <mav_msgs/conversions.h>
+#include <mav_msgs/eigen_mav_msgs.h>
+#include <mav_planning_common/physical_constraints.h>
+#include <mav_planning_msgs/PolynomialTrajectory4D.h>
+#include <mav_visualization/helpers.h>
+#include <minkindr_conversions/kindr_msg.h>
+#include <voxblox_ros/esdf_server.h>
+
 namespace mav_planning {
 
 class MavLocalPlanner {
@@ -8,6 +23,7 @@ class MavLocalPlanner {
   MavLocalPlanner(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
 
   // Input data.
+  void odometryCallback(const nav_msgs::Odometry& msg);
   void waypointCallback(const geometry_msgs::PoseStamped& msg);
   void waypointListCallback(const geometry_msgs::PoseArray& msg);
 
@@ -30,11 +46,13 @@ class MavLocalPlanner {
       const mav_planning_msgs::PolynomialTrajectory4D& msg) {}
 
  private:
+  // Control for publishing.
+  void startPublishingCommands();
+  void commandPublishTimerCallback(const ros::TimerEvent& event);
+
+
+
   // Functions to help out replanning.
-
-
-
-
 
   ros::NodeHandle nh_;
   ros::NodeHandle nh_private_;
@@ -66,6 +84,9 @@ class MavLocalPlanner {
   ros::CallbackQueue command_publishing_queue_;
   ros::AsyncSpinner command_publishing_spinner_;
 
+  // Publisher for new messages to the controller.
+  ros::Timer command_publishing_timer_;
+
   // Settings -- general
   bool verbose_;
 
@@ -78,6 +99,8 @@ class MavLocalPlanner {
 
   // Settings -- controller interface.
   int mpc_prediction_horizon_;  // Units: timesteps.
+  // TODO(helenol): do I need these two to be separate? I guess so...
+  double command_publishing_dt_;
   double replan_dt_;
 
   // Settings -- general planning.
@@ -102,7 +125,6 @@ class MavLocalPlanner {
   voxblox::EsdfServer esdf_server_;
 
   // Planners.
-
 };
 
 }  // namespace mav_planning

--- a/mav_local_planner/include/mav_local_planner/mav_local_planner.h
+++ b/mav_local_planner/include/mav_local_planner/mav_local_planner.h
@@ -14,6 +14,7 @@
 #include <mav_planning_common/path_utils.h>
 #include <mav_planning_common/path_visualization.h>
 #include <mav_planning_common/physical_constraints.h>
+#include <mav_planning_common/yaw_policy.h>
 #include <mav_planning_msgs/PolynomialTrajectory4D.h>
 #include <mav_visualization/helpers.h>
 #include <minkindr_conversions/kindr_msg.h>
@@ -153,12 +154,13 @@ class MavLocalPlanner {
   // Map!
   voxblox::EsdfServer esdf_server_;
 
+  // Planners -- yaw policy
+  YawPolicy yaw_policy_;
+
   // Planners -- local planners.
   VoxbloxLocoPlanner loco_planner_;
 
   // Planners -- path smoothers.
-
-
 };
 
 }  // namespace mav_planning

--- a/mav_local_planner/include/mav_local_planner/mav_local_planner.h
+++ b/mav_local_planner/include/mav_local_planner/mav_local_planner.h
@@ -45,6 +45,9 @@ class MavLocalPlanner {
   bool stopCallback(std_srvs::Empty::Request& request,
                     std_srvs::Empty::Response& response);
 
+  // Visualizations.
+  void visualizePath();
+
   // TODO -- TO IMPLEMENT:
   void polynomialTrajectoryCallback(
       const mav_planning_msgs::PolynomialTrajectory4D& msg) {}

--- a/mav_local_planner/include/mav_local_planner/mav_local_planner.h
+++ b/mav_local_planner/include/mav_local_planner/mav_local_planner.h
@@ -14,6 +14,7 @@
 #include <mav_planning_common/path_utils.h>
 #include <mav_planning_common/path_visualization.h>
 #include <mav_planning_common/physical_constraints.h>
+#include <mav_planning_common/semaphore.h>
 #include <mav_planning_common/yaw_policy.h>
 #include <mav_planning_msgs/PolynomialTrajectory4D.h>
 #include <mav_visualization/helpers.h>
@@ -105,8 +106,11 @@ class MavLocalPlanner {
 
   // ROS async handling: callback queues and spinners for command publishing,
   // which is on a separate thread from the rest of the functions.
+  // Same for planning.
   ros::CallbackQueue command_publishing_queue_;
   ros::AsyncSpinner command_publishing_spinner_;
+  ros::CallbackQueue planning_queue_;
+  ros::AsyncSpinner planning_spinner_;
 
   // Publisher for new messages to the controller.
   ros::Timer command_publishing_timer_;
@@ -145,7 +149,9 @@ class MavLocalPlanner {
   mav_msgs::EigenTrajectoryPointVector path_queue_;
   size_t path_index_;
   // Super important: mutex for locking the path queues.
-  std::mutex path_mutex_;
+  std::recursive_mutex path_mutex_;
+  std::recursive_mutex map_mutex_;
+  RosSemaphore should_replan_;
 
   // State -- planning.
   int max_failures_;

--- a/mav_local_planner/include/mav_local_planner/mav_local_planner.h
+++ b/mav_local_planner/include/mav_local_planner/mav_local_planner.h
@@ -10,6 +10,9 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <mav_msgs/conversions.h>
 #include <mav_msgs/eigen_mav_msgs.h>
+#include <mav_path_smoothing/loco_smoother.h>
+#include <mav_path_smoothing/polynomial_smoother.h>
+#include <mav_path_smoothing/velocity_ramp_smoother.h>
 #include <mav_planning_common/color_utils.h>
 #include <mav_planning_common/path_utils.h>
 #include <mav_planning_common/path_visualization.h>
@@ -63,10 +66,15 @@ class MavLocalPlanner {
   void planningTimerCallback(const ros::TimerEvent& event);
   void planningStep();
   void nextWaypoint();
+  void replacePath(const mav_msgs::EigenTrajectoryPointVector& path);
 
   // Functions to help out replanning.
   // Track a single waypoint, planning only in a short known horizon.
   void avoidCollisionsTowardWaypoint();
+  // Get a path through a bunch of waypoints.
+  bool planPathThroughWaypoints(
+      const mav_msgs::EigenTrajectoryPointVector& waypoints,
+      mav_msgs::EigenTrajectoryPointVector* path);
 
   // Map access.
   double getMapDistance(const Eigen::Vector3d& position) const;
@@ -139,6 +147,7 @@ class MavLocalPlanner {
   bool avoid_collisions_;
   bool autostart_;  // Whether to auto-start publishing any new path or wait
   // for start service call.
+  std::string smoother_name_;
 
   // State -- robot state.
   mav_msgs::EigenOdometry odometry_;
@@ -169,6 +178,9 @@ class MavLocalPlanner {
   VoxbloxLocoPlanner loco_planner_;
 
   // Planners -- path smoothers.
+  VelocityRampSmoother ramp_smoother_;
+  PolynomialSmoother poly_smoother_;
+  LocoSmoother loco_smoother_;
 };
 
 }  // namespace mav_planning

--- a/mav_local_planner/include/mav_local_planner/mav_local_planner.h
+++ b/mav_local_planner/include/mav_local_planner/mav_local_planner.h
@@ -1,0 +1,110 @@
+#ifndef MAV_LOCAL_PLANNER_MAV_LOCAL_PLANNER_H_
+#define MAV_LOCAL_PLANNER_MAV_LOCAL_PLANNER_H_
+
+namespace mav_planning {
+
+class MavLocalPlanner {
+ public:
+  MavLocalPlanner(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
+
+  // Input data.
+  void waypointCallback(const geometry_msgs::PoseStamped& msg);
+  void waypointListCallback(const geometry_msgs::PoseArray& msg);
+
+  // Stops path publishing and clears all recent trajectories.
+  void clearTrajectory();
+  // Same as above, but also sends the current pose of the helicopter to the
+  // controller to clear the queue.
+  void abort();
+
+  // Service callbacks.
+  bool startCallback(std_srvs::Empty::Request& request,
+                     std_srvs::Empty::Response& response);
+  bool pauseCallback(std_srvs::Empty::Request& request,
+                     std_srvs::Empty::Response& response);
+  bool stopCallback(std_srvs::Empty::Request& request,
+                    std_srvs::Empty::Response& response);
+
+  // TODO -- TO IMPLEMENT:
+  void polynomialTrajectoryCallback(
+      const mav_planning_msgs::PolynomialTrajectory4D& msg) {}
+
+ private:
+  // Functions to help out replanning.
+
+
+
+
+
+  ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
+
+  // ROS inputs and outputs.
+  ros::Subscriber waypoint_sub_;
+  ros::Subscriber waypoint_list_sub_;
+  // Current state of the MAV.
+  ros::Subscriber odometry_sub_;
+
+  ros::Publisher command_pub_;
+  ros::Publisher path_marker_pub_;
+  ros::Publisher full_trajectory_pub_;
+
+  // Service calls for controlling the local planner.
+  // Start will start publishing commands, pause will stop temporarily and you
+  // can call start to un-pause, and stop will stop and clear the current
+  // trajectory.
+  ros::ServiceServer start_srv_;
+  ros::ServiceServer pause_srv_;
+  ros::ServiceServer stop_srv_;
+
+  // Service client for getting the MAV interface to listen to our sent
+  // commands.
+  ros::ServiceClient position_hold_client_;
+
+  // ROS async handling: callback queues and spinners for command publishing,
+  // which is on a separate thread from the rest of the functions.
+  ros::CallbackQueue command_publishing_queue_;
+  ros::AsyncSpinner command_publishing_spinner_;
+
+  // Settings -- general
+  bool verbose_;
+
+  // Settings -- frames
+  std::string global_frame_id_;
+  std::string local_frame_id_;
+
+  // Settings -- constraints.
+  PhysicalConstraints constraints_;
+
+  // Settings -- controller interface.
+  int mpc_prediction_horizon_;  // Units: timesteps.
+  double replan_dt_;
+
+  // Settings -- general planning.
+  bool use_obstacle_avoidance_;
+  bool autostart_;  // Whether to auto-start publishing any new path or wait
+  // for start service call.
+
+  // State -- robot state.
+  mav_msgs::EigenOdometry odometry_;
+
+  // State -- waypoints.
+  mav_msgs::EigenTrajectoryPointVector waypoints_;
+  int current_waypoint_;
+
+  // State -- current tracked path.
+  mav_msgs::EigenTrajectoryPointVector path_;
+  size_t path_index_;
+  // Super important: mutex for locking the path queues.
+  std::mutex path_mutex_;
+
+  // Map!
+  voxblox::EsdfServer esdf_server_;
+
+  // Planners.
+
+};
+
+}  // namespace mav_planning
+
+#endif  // MAV_LOCAL_PLANNER_MAV_LOCAL_PLANNER_H_

--- a/mav_local_planner/include/mav_local_planner/mav_local_planner.h
+++ b/mav_local_planner/include/mav_local_planner/mav_local_planner.h
@@ -58,7 +58,9 @@ class MavLocalPlanner {
   void commandPublishTimerCallback(const ros::TimerEvent& event);
 
   // Control for planning.
+  void planningTimerCallback(const ros::TimerEvent& event);
   void planningStep();
+  void nextWaypoint();
 
   // Functions to help out replanning.
 
@@ -107,6 +109,7 @@ class MavLocalPlanner {
 
   // Publisher for new messages to the controller.
   ros::Timer command_publishing_timer_;
+  ros::Timer planning_timer_;
 
   // Settings -- general
   bool verbose_;
@@ -143,6 +146,10 @@ class MavLocalPlanner {
   // Super important: mutex for locking the path queues.
   std::mutex path_mutex_;
 
+  // State -- planning.
+  int max_failures_;
+  int num_failures_;
+
   // Map!
   voxblox::EsdfServer esdf_server_;
 
@@ -150,6 +157,8 @@ class MavLocalPlanner {
   VoxbloxLocoPlanner loco_planner_;
 
   // Planners -- path smoothers.
+
+
 };
 
 }  // namespace mav_planning

--- a/mav_local_planner/include/mav_local_planner/mav_local_planner.h
+++ b/mav_local_planner/include/mav_local_planner/mav_local_planner.h
@@ -65,6 +65,8 @@ class MavLocalPlanner {
   void nextWaypoint();
 
   // Functions to help out replanning.
+  // Track a single waypoint, planning only in a short known horizon.
+  void avoidCollisionsTowardWaypoint();
 
   // Map access.
   double getMapDistance(const Eigen::Vector3d& position) const;
@@ -134,7 +136,7 @@ class MavLocalPlanner {
   double replan_lookahead_sec_;
 
   // Settings -- general planning.
-  bool use_obstacle_avoidance_;
+  bool avoid_collisions_;
   bool autostart_;  // Whether to auto-start publishing any new path or wait
   // for start service call.
 

--- a/mav_local_planner/launch/firefly_just_planner.launch
+++ b/mav_local_planner/launch/firefly_just_planner.launch
@@ -57,6 +57,7 @@
       <param name="verbose" value="true" />
       <param name="v_max" value="1.0" />
       <param name="a_max" value="2.0" />
+      <param name="avoid_collisions" value="false" />
     </node>
   </group>
 </launch>

--- a/mav_local_planner/launch/firefly_just_planner.launch
+++ b/mav_local_planner/launch/firefly_just_planner.launch
@@ -1,0 +1,28 @@
+<launch>
+  <arg name="mav_name" default="firefly"/>
+  <arg name="frame_id" default="odom" />
+  <!-- The following line causes gzmsg and gzerr messages to be printed to the console
+      (even when Gazebo is started through roslaunch) -->
+  <arg name="verbose" default="false"/>
+
+
+  <group ns="$(arg mav_name)">
+    <node name="mav_local_planner" pkg="mav_local_planner" type="mav_local_planner_node" output="screen">
+      <remap from="odometry" to="ground_truth/odometry" />
+      <remap from="mav_local_planner/esdf_map_in" to="esdf_map" />
+      <remap from="mav_local_planner/tsdf_map_in" to="tsdf_map" />
+      <param name="tsdf_voxel_size" value="0.20" />
+      <param name="tsdf_voxels_per_side" value="16" />
+      <param name="esdf_max_distance_m" value="2.0" />
+      <param name="update_mesh_every_n_sec" value="0.0" />
+      <param name="replan_dt" value="0.25" />
+      <param name="local_frame_id" value="$(arg frame_id)" />
+      <param name="world_frame" value="$(arg frame_id)" />
+      <param name="publish_traversable" value="true" />
+      <param name="verbose" value="true" />
+      <param name="autostart" value="true" />
+      <param name="slice_level" value="1.0" />
+      <param name="robot_radius" value="0.5" />
+    </node>
+  </group>
+</launch>

--- a/mav_local_planner/launch/firefly_just_planner.launch
+++ b/mav_local_planner/launch/firefly_just_planner.launch
@@ -7,6 +7,31 @@
 
 
   <group ns="$(arg mav_name)">
+    <node name="voxblox_node" pkg="voxblox_ros" type="esdf_server" output="screen" args="-alsologtostderr" clear_params="true">
+      <remap from="pointcloud" to="vi_sensor/camera_depth/depth/points"/>
+      <remap from="voxblox_node/esdf_map_out" to="esdf_map" />
+      <remap from="voxblox_node/tsdf_map_out" to="tsdf_map" />
+      <param name="method" value="fast" />
+      <param name="publish_tsdf_map" value="true" />
+      <param name="publish_esdf_map" value="true" />
+      <param name="tsdf_voxel_size" value="0.20" />
+      <param name="tsdf_voxels_per_side" value="16" />
+      <param name="esdf_max_distance_m" value="2.0" />
+      <param name="max_ray_length_m" value="10.0" />
+      <param name="voxel_carving_enabled" value="true" />
+      <param name="color_mode" value="color" />
+      <param name="use_tf_transforms" value="true" />
+      <param name="update_mesh_every_n_sec" value="0.25" />
+      <param name="min_time_between_msgs_sec" value="0.10" />
+      <param name="clear_sphere_for_planning" value="true" />
+      <param name="occupied_sphere_radius" value="4.0" />
+      <param name="clear_sphere_radius" value="1.0" />
+      <param name="slice_level" value="1.0" />
+      <param name="world_frame" value="$(arg frame_id)" />
+      <param name="verbose" value="false" />
+    </node>
+
+
     <node name="mav_local_planner" pkg="mav_local_planner" type="mav_local_planner_node" output="screen">
       <remap from="odometry" to="ground_truth/odometry" />
       <remap from="mav_local_planner/esdf_map_in" to="esdf_map" />
@@ -23,7 +48,7 @@
       <param name="publish_traversable" value="true" />
       <param name="verbose" value="true" />
       <param name="autostart" value="true" />
-      <param name="slice_level" value="1.5" />
+      <param name="slice_level" value="1.0" />
       <param name="robot_radius" value="0.5" />
       <param name="publish_slices" value="true" />
     </node>

--- a/mav_local_planner/launch/firefly_just_planner.launch
+++ b/mav_local_planner/launch/firefly_just_planner.launch
@@ -15,14 +15,17 @@
       <param name="tsdf_voxels_per_side" value="16" />
       <param name="esdf_max_distance_m" value="2.0" />
       <param name="update_mesh_every_n_sec" value="0.0" />
-      <param name="replan_dt" value="0.25" />
+      <param name="replan_dt" value="1.0" />
+      <param name="command_publishing_dt" value="1.0" />
+      <param name="replan_lookahead_sec" value="1.0" />
       <param name="local_frame_id" value="$(arg frame_id)" />
       <param name="world_frame" value="$(arg frame_id)" />
       <param name="publish_traversable" value="true" />
       <param name="verbose" value="true" />
       <param name="autostart" value="true" />
-      <param name="slice_level" value="1.0" />
+      <param name="slice_level" value="1.5" />
       <param name="robot_radius" value="0.5" />
+      <param name="publish_slices" value="true" />
     </node>
   </group>
 </launch>

--- a/mav_local_planner/launch/firefly_just_planner.launch
+++ b/mav_local_planner/launch/firefly_just_planner.launch
@@ -40,17 +40,23 @@
       <param name="tsdf_voxels_per_side" value="16" />
       <param name="esdf_max_distance_m" value="2.0" />
       <param name="update_mesh_every_n_sec" value="0.0" />
-      <param name="replan_dt" value="1.0" />
-      <param name="command_publishing_dt" value="1.0" />
-      <param name="replan_lookahead_sec" value="1.0" />
+      <param name="publish_traversable" value="true" />
+      <param name="slice_level" value="1.0" />
+      <param name="publish_slices" value="true" />
+
       <param name="local_frame_id" value="$(arg frame_id)" />
       <param name="world_frame" value="$(arg frame_id)" />
-      <param name="publish_traversable" value="true" />
-      <param name="verbose" value="true" />
-      <param name="autostart" value="true" />
-      <param name="slice_level" value="1.0" />
+      <param name="replan_dt" value="0.25" />
+      <param name="command_publishing_dt" value="0.25" />
+      <param name="replan_lookahead_sec" value="1.0" />
+      <param name="mpc_prediction_horizon" value="300" />
+
       <param name="robot_radius" value="0.5" />
-      <param name="publish_slices" value="true" />
+      <param name="planning_horizon_m" value="4.0" />
+      <param name="autostart" value="true" />
+      <param name="verbose" value="true" />
+      <param name="v_max" value="1.0" />
+      <param name="a_max" value="2.0" />
     </node>
   </group>
 </launch>

--- a/mav_local_planner/launch/firefly_mapping_planning.launch
+++ b/mav_local_planner/launch/firefly_mapping_planning.launch
@@ -1,10 +1,7 @@
 <launch>
   <arg name="mav_name" default="firefly"/>
   <arg name="frame_id" default="odom" />
-  <!-- The following line causes gzmsg and gzerr messages to be printed to the console
-      (even when Gazebo is started through roslaunch) -->
   <arg name="verbose" default="false"/>
-
 
   <group ns="$(arg mav_name)">
     <node name="voxblox_node" pkg="voxblox_ros" type="esdf_server" output="screen" args="-alsologtostderr" clear_params="true">
@@ -55,9 +52,9 @@
       <param name="planning_horizon_m" value="4.0" />
       <param name="autostart" value="true" />
       <param name="verbose" value="true" />
-      <param name="v_max" value="1.0" />
+      <param name="v_max" value="2.0" />
       <param name="a_max" value="2.0" />
-      <param name="avoid_collisions" value="false" />
+      <param name="avoid_collisions" value="true" />
     </node>
   </group>
 </launch>

--- a/mav_local_planner/launch/firefly_sim.launch
+++ b/mav_local_planner/launch/firefly_sim.launch
@@ -1,0 +1,97 @@
+<launch>
+  <arg name="mav_name" default="firefly"/>
+  <arg name="world_name" default="basic"/>
+  <arg name="enable_logging" default="false" />
+  <arg name="enable_ground_truth" default="true" />
+  <arg name="log_file" default="$(arg mav_name)" />
+  <arg name="debug" default="false"/>
+  <arg name="gui" default="true"/>
+  <arg name="paused" default="false"/>
+  <arg name="frame_id" default="odom" />
+  <!-- The following line causes gzmsg and gzerr messages to be printed to the console
+      (even when Gazebo is started through roslaunch) -->
+  <arg name="verbose" default="false"/>
+
+  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
+  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world" />
+    <arg name="debug" value="$(arg debug)" />
+    <arg name="paused" value="$(arg paused)" />
+    <arg name="gui" value="$(arg gui)" />
+    <arg name="verbose" value="$(arg verbose)"/>
+  </include>
+
+  <group ns="$(arg mav_name)">
+    <include file="$(find rotors_gazebo)/launch/spawn_mav.launch">
+      <arg name="mav_name" value="$(arg mav_name)" />
+      <arg name="model" value="$(find rotors_description)/urdf/mav_with_vi_sensor.gazebo" />
+      <arg name="enable_logging" value="$(arg enable_logging)" />
+      <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+      <arg name="log_file" value="$(arg log_file)"/>
+    </include>
+
+    <node name="mav_nonlinear_mpc" pkg="mav_nonlinear_mpc" type="nonlinear_mpc_node" respawn="true" clear_params="true" output="screen">
+      <remap from="odometry" to="ground_truth/odometry" />
+      <rosparam file="$(find mav_nonlinear_mpc)/resources/nonlinear_mpc_$(arg mav_name).yaml" />
+      <rosparam file="$(find mav_disturbance_observer)/resources/disturbance_observer_$(arg mav_name).yaml"/>
+      <param name="use_rc_teleop" value="false"/>
+      <param name="verbose" value="true" />
+      <param name="reference_frame" value="$(arg frame_id)"/>
+    </node>
+
+    <node name="PID_attitude_controller" pkg="mav_lowlevel_attitude_controller" type="mav_pid_attitude_controller_node" respawn="true" clear_params="true" output="screen">
+      <remap from="odometry" to="ground_truth/odometry" />
+      <rosparam file="$(find mav_lowlevel_attitude_controller)/resources/PID_attitude_$(arg mav_name).yaml" />
+    </node>
+
+    <node name="hovering_example" pkg="rotors_gazebo" type="hovering_example" output="screen" >
+    </node>
+
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+    <!-- <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" /> -->
+
+    <!-- Transforms -->
+    <node pkg="tf" type="static_transform_publisher" name="world_odom_broadcaster" args="0 0 0 0 0 0 1 world odom 100" />
+
+    <!-- Mapping -->
+    <node name="voxblox_node" pkg="voxblox_ros" type="esdf_server" output="screen" args="-alsologtostderr" clear_params="true">
+      <remap from="pointcloud" to="vi_sensor/camera_depth/depth/points"/>
+      <remap from="voxblox_node/esdf_map_out" to="esdf_map" />
+      <remap from="voxblox_node/tsdf_map_out" to="tsdf_map" />
+      <param name="publish_tsdf_map" value="true" />
+      <param name="publish_esdf_map" value="true" />
+      <param name="tsdf_voxel_size" value="0.20" />
+      <param name="tsdf_voxels_per_side" value="16" />
+      <param name="esdf_max_distance_m" value="2.0" />
+      <param name="voxel_carving_enabled" value="true" />
+      <param name="color_mode" value="color" />
+      <param name="use_tf_transforms" value="true" />
+      <param name="update_mesh_every_n_sec" value="0.25" />
+      <param name="min_time_between_msgs_sec" value="0.5" />
+      <param name="clear_sphere_for_planning" value="true" />
+      <param name="occupied_sphere_radius" value="4.0" />
+      <param name="clear_sphere_radius" value="1.5" />
+      <param name="slice_level" value="1.0" />
+      <param name="world_frame" value="$(arg frame_id)" />
+      <param name="verbose" value="true" />
+    </node>
+
+    <!-- Planning -->
+    <node name="mav_local_planner" pkg="mav_local_planner" type="mav_local_planner_node" output="screen" if="false">
+      <remap from="odometry" to="ground_truth/odometry" />
+      <remap from="mav_local_planner/esdf_map_in" to="esdf_map" />
+      <remap from="mav_local_planner/tsdf_map_in" to="tsdf_map" />
+      <param name="tsdf_voxel_size" value="0.20" />
+      <param name="tsdf_voxels_per_side" value="16" />
+      <param name="esdf_max_distance_m" value="2.0" />
+      <param name="update_mesh_every_n_sec" value="0.0" />
+      <param name="replan_dt" value="0.25" />
+      <param name="local_frame_id" value="$(arg frame_id)" />
+      <param name="world_frame" value="$(arg frame_id)" />
+      <param name="publish_traversable" value="true" />
+      <param name="verbose" value="true" />
+      <param name="autostart" value="true" />
+    </node>
+  </group>
+</launch>

--- a/mav_local_planner/launch/firefly_sim.launch
+++ b/mav_local_planner/launch/firefly_sim.launch
@@ -36,16 +36,7 @@
       <rosparam file="$(find mav_nonlinear_mpc)/resources/nonlinear_mpc_$(arg mav_name).yaml" />
       <rosparam file="$(find mav_disturbance_observer)/resources/disturbance_observer_$(arg mav_name).yaml"/>
       <param name="use_rc_teleop" value="false"/>
-      <param name="verbose" value="true" />
-      <param name="reference_frame" value="$(arg frame_id)"/>
-    </node>
-
-    <node name="mav_linear_mpc" pkg="mav_linear_mpc" type="mav_linear_mpc_node" respawn="true" clear_params="true" output="screen" if="false">
-      <remap from="odometry" to="odometry_sensor1/odometry" />
-      <rosparam file="$(find mav_linear_mpc)/resources/linear_mpc_$(arg mav_name).yaml" />
-      <rosparam file="$(find mav_disturbance_observer)/resources/disturbance_observer_$(arg mav_name).yaml"/>
-      <param name="verbose" value="true" />
-      <param name="use_rc_teleop" value="false" />
+      <param name="verbose" value="false" />
       <param name="reference_frame" value="$(arg frame_id)"/>
     </node>
 
@@ -58,51 +49,11 @@
     </node>
 
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-    <!-- <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" /> -->
 
     <!-- Transforms -->
     <node pkg="tf" type="static_transform_publisher" name="world_odom_broadcaster" args="0 0 0 0 0 0 1 world odom 100" />
-
-    <!-- Mapping -->
-    <node name="voxblox_node" pkg="voxblox_ros" type="esdf_server" output="screen" args="-alsologtostderr" clear_params="true">
-      <remap from="pointcloud" to="vi_sensor/camera_depth/depth/points"/>
-      <remap from="voxblox_node/esdf_map_out" to="esdf_map" />
-      <remap from="voxblox_node/tsdf_map_out" to="tsdf_map" />
-      <param name="method" value="fast" />
-      <param name="publish_tsdf_map" value="true" />
-      <param name="publish_esdf_map" value="true" />
-      <param name="tsdf_voxel_size" value="0.20" />
-      <param name="tsdf_voxels_per_side" value="16" />
-      <param name="esdf_max_distance_m" value="2.0" />
-      <param name="max_ray_length_m" value="10.0" />
-      <param name="voxel_carving_enabled" value="true" />
-      <param name="color_mode" value="color" />
-      <param name="use_tf_transforms" value="true" />
-      <param name="update_mesh_every_n_sec" value="0.25" />
-      <param name="min_time_between_msgs_sec" value="0.10" />
-      <param name="clear_sphere_for_planning" value="true" />
-      <param name="occupied_sphere_radius" value="4.0" />
-      <param name="clear_sphere_radius" value="2.0" />
-      <param name="slice_level" value="1.0" />
-      <param name="world_frame" value="$(arg frame_id)" />
-      <param name="verbose" value="false" />
-    </node>
-
-    <!-- Planning -->
-    <node name="mav_local_planner" pkg="mav_local_planner" type="mav_local_planner_node" output="screen" if="false">
-      <remap from="odometry" to="ground_truth/odometry" />
-      <remap from="mav_local_planner/esdf_map_in" to="esdf_map" />
-      <remap from="mav_local_planner/tsdf_map_in" to="tsdf_map" />
-      <param name="tsdf_voxel_size" value="0.20" />
-      <param name="tsdf_voxels_per_side" value="16" />
-      <param name="esdf_max_distance_m" value="2.0" />
-      <param name="update_mesh_every_n_sec" value="0.0" />
-      <param name="replan_dt" value="0.25" />
-      <param name="local_frame_id" value="$(arg frame_id)" />
-      <param name="world_frame" value="$(arg frame_id)" />
-      <param name="publish_traversable" value="true" />
-      <param name="verbose" value="true" />
-      <param name="autostart" value="true" />
-    </node>
   </group>
+
+  <!-- Mapping and Planning -->
+  <include file="$(find mav_local_planner)/launch/firefly_mapping_planning.launch"/>
 </launch>

--- a/mav_local_planner/launch/firefly_sim.launch
+++ b/mav_local_planner/launch/firefly_sim.launch
@@ -31,12 +31,21 @@
       <arg name="log_file" value="$(arg log_file)"/>
     </include>
 
-    <node name="mav_nonlinear_mpc" pkg="mav_nonlinear_mpc" type="nonlinear_mpc_node" respawn="true" clear_params="true" output="screen">
+    <node name="mav_nonlinear_mpc" pkg="mav_nonlinear_mpc" type="nonlinear_mpc_node" respawn="true" clear_params="true" output="screen" >
       <remap from="odometry" to="ground_truth/odometry" />
       <rosparam file="$(find mav_nonlinear_mpc)/resources/nonlinear_mpc_$(arg mav_name).yaml" />
       <rosparam file="$(find mav_disturbance_observer)/resources/disturbance_observer_$(arg mav_name).yaml"/>
       <param name="use_rc_teleop" value="false"/>
       <param name="verbose" value="true" />
+      <param name="reference_frame" value="$(arg frame_id)"/>
+    </node>
+
+    <node name="mav_linear_mpc" pkg="mav_linear_mpc" type="mav_linear_mpc_node" respawn="true" clear_params="true" output="screen" if="false">
+      <remap from="odometry" to="odometry_sensor1/odometry" />
+      <rosparam file="$(find mav_linear_mpc)/resources/linear_mpc_$(arg mav_name).yaml" />
+      <rosparam file="$(find mav_disturbance_observer)/resources/disturbance_observer_$(arg mav_name).yaml"/>
+      <param name="verbose" value="true" />
+      <param name="use_rc_teleop" value="false" />
       <param name="reference_frame" value="$(arg frame_id)"/>
     </node>
 
@@ -59,22 +68,24 @@
       <remap from="pointcloud" to="vi_sensor/camera_depth/depth/points"/>
       <remap from="voxblox_node/esdf_map_out" to="esdf_map" />
       <remap from="voxblox_node/tsdf_map_out" to="tsdf_map" />
+      <param name="method" value="fast" />
       <param name="publish_tsdf_map" value="true" />
       <param name="publish_esdf_map" value="true" />
       <param name="tsdf_voxel_size" value="0.20" />
       <param name="tsdf_voxels_per_side" value="16" />
       <param name="esdf_max_distance_m" value="2.0" />
+      <param name="max_ray_length_m" value="10.0" />
       <param name="voxel_carving_enabled" value="true" />
       <param name="color_mode" value="color" />
       <param name="use_tf_transforms" value="true" />
       <param name="update_mesh_every_n_sec" value="0.25" />
-      <param name="min_time_between_msgs_sec" value="0.5" />
+      <param name="min_time_between_msgs_sec" value="0.10" />
       <param name="clear_sphere_for_planning" value="true" />
       <param name="occupied_sphere_radius" value="4.0" />
-      <param name="clear_sphere_radius" value="1.5" />
+      <param name="clear_sphere_radius" value="2.0" />
       <param name="slice_level" value="1.0" />
       <param name="world_frame" value="$(arg frame_id)" />
-      <param name="verbose" value="true" />
+      <param name="verbose" value="false" />
     </node>
 
     <!-- Planning -->

--- a/mav_local_planner/launch/firefly_sim.launch
+++ b/mav_local_planner/launch/firefly_sim.launch
@@ -1,6 +1,6 @@
 <launch>
   <arg name="mav_name" default="firefly"/>
-  <arg name="world_name" default="basic"/>
+  <arg name="world_name" default="$(find mav_local_planner)/worlds/maze_house.world"/>
   <arg name="enable_logging" default="false" />
   <arg name="enable_ground_truth" default="true" />
   <arg name="log_file" default="$(arg mav_name)" />
@@ -15,7 +15,7 @@
   <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
   <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
-    <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world" />
+    <arg name="world_name" value="$(arg world_name)" />
     <arg name="debug" value="$(arg debug)" />
     <arg name="paused" value="$(arg paused)" />
     <arg name="gui" value="$(arg gui)" />

--- a/mav_local_planner/package.xml
+++ b/mav_local_planner/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>mav_local_planner</name>
+  <version>0.0.0</version>
+  <description>
+    Local planning using various path smoothing methods, LOCO for avoidance, interpolating between local and global coordinate frames, and cooking you dinner.
+  </description>
+
+  <maintainer email="helen.oleynikova@mavt.ethz.ch">Helen Oleynikova</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>catkin_simple</buildtool_depend>
+
+  <depend>mav_msgs</depend>
+  <depend>mav_path_smoothing</depend>
+  <depend>mav_planning_common</depend>
+  <depend>mav_planning_msgs</depend>
+  <depend>mav_trajectory_generation_ros</depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>tf</depend>
+  <depend>visualization_msgs</depend>
+  <depend>voxblox_loco_planner</depend>
+  <depend>voxblox_ros</depend>
+</package>

--- a/mav_local_planner/src/mav_local_planner.cpp
+++ b/mav_local_planner/src/mav_local_planner.cpp
@@ -118,12 +118,8 @@ void MavLocalPlanner::waypointListCallback(
 
 void MavLocalPlanner::planningTimerCallback(const ros::TimerEvent& event) {
   // Wait on the condition variable from the publishing...
-  std::cerr << "Waiting.\n";
   if (should_replan_.wait_for(replan_dt_)) {
-    std::cerr << "Waited.\n";
     planningStep();
-  } else {
-    std::cerr << "Failed to wait.\n";
   }
 }
 
@@ -161,7 +157,6 @@ void MavLocalPlanner::planningStep() {
     mav_msgs::EigenTrajectoryPointVector path_chunk;
     size_t replan_start_index;
     {
-      // std::lock_guard<std::mutex> guard(path_mutex_);
       replan_start_index =
           std::min(path_index_ + static_cast<size_t>((replan_lookahead_sec_) /
                                                      constraints_.sampling_dt),
@@ -237,7 +232,6 @@ void MavLocalPlanner::planningStep() {
             path_chunk.front().orientation_W_B;
         yaw_policy_.applyPolicyInPlace(&new_path_chunk);
 
-        // std::lock_guard<std::recursive_mutex> guard(path_mutex_);
         // Remove what was in the trajectory before.
         if (replan_start_index < path_queue_.size()) {
           path_queue_.erase(path_queue_.begin() + replan_start_index,

--- a/mav_local_planner/src/mav_local_planner.cpp
+++ b/mav_local_planner/src/mav_local_planner.cpp
@@ -1,3 +1,5 @@
+#include <mav_msgs/default_topics.h>
+
 #include "mav_local_planner/mav_local_planner.h"
 
 namespace mav_planning {
@@ -11,6 +13,7 @@ MavLocalPlanner::MavLocalPlanner(const ros::NodeHandle& nh,
       global_frame_id_("map"),
       local_frame_id_("odom"),
       mpc_prediction_horizon_(300),
+      command_publishing_dt_(1.0),
       replan_dt_(1.0),
       use_obstacle_avoidance_(true),
       autostart_(true),
@@ -18,7 +21,7 @@ MavLocalPlanner::MavLocalPlanner(const ros::NodeHandle& nh,
       path_index_(0),
       esdf_server_(nh_, nh_private_) {
   constraints_.setParametersFromRos(nh_private_);
-  esdf_server_->setTraversabilityRadius(constraints_.robot_radius);
+  esdf_server_.setTraversabilityRadius(constraints_.robot_radius);
 
   nh_private_.param("verbose", verbose_, verbose_);
   nh_private_.param("global_frame_id", global_frame_id_, global_frame_id_);
@@ -49,14 +52,82 @@ MavLocalPlanner::MavLocalPlanner(const ros::NodeHandle& nh,
 
   // Services.
   start_srv_ = nh_private_.advertiseService(
-      "start", &LocalPlannerNode::startCallback, this);
+      "start", &MavLocalPlanner::startCallback, this);
   pause_srv_ = nh_private_.advertiseService(
-      "pause", &LocalPlannerNode::pauseCallback, this);
+      "pause", &MavLocalPlanner::pauseCallback, this);
   stop_srv_ = nh_private_.advertiseService(
-      "stop", &LocalPlannerNode::stopCallback, this);
+      "stop", &MavLocalPlanner::stopCallback, this);
 
   // Start the command publishing spinner.
   command_publishing_spinner_.start();
+}
+
+void MavLocalPlanner::odometryCallback(const nav_msgs::Odometry& msg) {
+  mav_msgs::eigenOdometryFromMsg(msg, &odometry_);
+}
+
+void MavLocalPlanner::waypointCallback(const geometry_msgs::PoseStamped& msg) {
+  // Plan a path from the current position to the target pose stamped.
+  ROS_INFO("[Mav Local Planner] Got a waypoint!");
+  // TODO(helenol): What do we do with clearing????
+  // Cancel any previous trajectory on getting a new one.
+  // clearTrajectory();
+
+  mav_msgs::EigenTrajectoryPoint waypoint;
+  eigenTrajectoryPointFromPoseMsg(msg, &waypoint);
+
+  // TODO!!!
+  // Do something here!
+  // Trigger replan?
+}
+
+void MavLocalPlanner::startPublishingCommands() {
+  // Call the service call to takeover publishing commands.
+  if (position_hold_client_.exists()) {
+    std_srvs::Empty empty_call;
+    position_hold_client_.call(empty_call);
+  }
+
+  // Publish the first set immediately, on this thread.
+  commandPublishTimerCallback(ros::TimerEvent());
+
+  // Need advanced timer options to assign callback queue to this timer.
+  ros::TimerOptions timer_options(
+      ros::Duration(command_publishing_dt_),
+      boost::bind(&MavLocalPlanner::commandPublishTimerCallback, this, _1),
+      &command_publishing_queue_);
+
+  command_publishing_timer_ = nh_.createTimer(timer_options);
+}
+
+void MavLocalPlanner::commandPublishTimerCallback(
+    const ros::TimerEvent& event) {
+  if (path_index_ < path_.size()) {
+    std::lock_guard<std::mutex> guard(path_mutex_);
+    size_t number_to_publish = std::min<size_t>(
+        std::floor(command_publishing_dt_ / constraints_.sampling_dt),
+        path_.size() - path_index_);
+
+    size_t number_to_publish_with_buffer =
+        std::min<size_t>(number_to_publish + mpc_prediction_horizon_,
+                         path_.size() - path_index_);
+
+    // TODO(helenol): do this without copy! Use iterators properly!
+    mav_msgs::EigenTrajectoryPointVector::const_iterator first_sample =
+        path_.begin() + path_index_;
+    mav_msgs::EigenTrajectoryPointVector::const_iterator last_sample =
+        first_sample + number_to_publish_with_buffer;
+    mav_msgs::EigenTrajectoryPointVector trajectory_to_publish(first_sample,
+                                                               last_sample);
+
+    trajectory_msgs::MultiDOFJointTrajectory msg;
+
+    mav_msgs::msgMultiDofJointTrajectoryFromEigen(trajectory_to_publish, &msg);
+
+    command_pub_.publish(msg);
+    path_index_ += number_to_publish;
+  }
+  // Does there need to be an else????
 }
 
 }  // namespace mav_planning

--- a/mav_local_planner/src/mav_local_planner.cpp
+++ b/mav_local_planner/src/mav_local_planner.cpp
@@ -75,7 +75,7 @@ void MavLocalPlanner::waypointCallback(const geometry_msgs::PoseStamped& msg) {
   ROS_INFO("[Mav Local Planner] Got a waypoint!");
   // TODO(helenol): What do we do with clearing????
   // Cancel any previous trajectory on getting a new one.
-  clearTrajectory();
+  //clearTrajectory();
 
   mav_msgs::EigenTrajectoryPoint waypoint;
   eigenTrajectoryPointFromPoseMsg(msg, &waypoint);
@@ -137,6 +137,7 @@ void MavLocalPlanner::planningStep() {
       ROS_INFO("path chunk length: %zu", path_chunk.size());
       if (path_chunk.size() == 0) {
         path_chunk.push_back(path_queue_.back());
+        path_chunk[0].time_from_start_ns = 0;
       }
     }
 
@@ -145,7 +146,7 @@ void MavLocalPlanner::planningStep() {
         "[Mav Local Planner][Plan Step] Existing chunk is collision free? %d",
         path_chunk_collision_free);
     // Check if the current path queue goes to the goal and is collision free.
-    if ((path_queue_.back().position_W - waypoint.position_W).norm() <
+    if ((path_chunk.back().position_W - waypoint.position_W).norm() <
         kCloseEnough) {
       // Collision check the remaining chunk of the trajectory.
       if (path_chunk_collision_free) {
@@ -203,6 +204,7 @@ void MavLocalPlanner::planningStep() {
     if (success) {
       // Copy this straight into the queue.
       std::lock_guard<std::mutex> guard(path_mutex_);
+      path_queue_.clear();
       mav_trajectory_generation::sampleWholeTrajectory(
           trajectory, constraints_.sampling_dt, &path_queue_);
       path_index_ = 0;

--- a/mav_local_planner/src/mav_local_planner.cpp
+++ b/mav_local_planner/src/mav_local_planner.cpp
@@ -1,0 +1,62 @@
+#include "mav_local_planner/mav_local_planner.h"
+
+namespace mav_planning {
+
+MavLocalPlanner::MavLocalPlanner(const ros::NodeHandle& nh,
+                                 const ros::NodeHandle& nh_private)
+    : nh_(nh),
+      nh_private_(nh_private),
+      command_publishing_spinner_(1, &command_publishing_queue_),
+      verbose_(false),
+      global_frame_id_("map"),
+      local_frame_id_("odom"),
+      mpc_prediction_horizon_(300),
+      replan_dt_(1.0),
+      use_obstacle_avoidance_(true),
+      autostart_(true),
+      current_waypoint_(-1),
+      path_index_(0),
+      esdf_server_(nh_, nh_private_) {
+  constraints_.setParametersFromRos(nh_private_);
+  esdf_server_->setTraversabilityRadius(constraints_.robot_radius);
+
+  nh_private_.param("verbose", verbose_, verbose_);
+  nh_private_.param("global_frame_id", global_frame_id_, global_frame_id_);
+  nh_private_.param("local_frame_id", local_frame_id_, local_frame_id_);
+  nh_private_.param("mpc_prediction_horizon", mpc_prediction_horizon_,
+                    mpc_prediction_horizon_);
+  nh_private_.param("replan_dt", replan_dt_, replan_dt_);
+  nh_private_.param("use_obstacle_avoidance", use_obstacle_avoidance_,
+                    use_obstacle_avoidance_);
+  nh_private_.param("autostart", autostart_, autostart_);
+
+  // Publishers and subscribers.
+  odometry_sub_ = nh_.subscribe(mav_msgs::default_topics::ODOMETRY, 1,
+                                &MavLocalPlanner::odometryCallback, this);
+  waypoint_sub_ =
+      nh_.subscribe("waypoint", 1, &MavLocalPlanner::waypointCallback, this);
+  waypoint_list_sub_ = nh_.subscribe(
+      "waypoint_list", 1, &MavLocalPlanner::waypointListCallback, this);
+
+  command_pub_ = nh_.advertise<trajectory_msgs::MultiDOFJointTrajectory>(
+      mav_msgs::default_topics::COMMAND_TRAJECTORY, 1);
+
+  path_marker_pub_ = nh_private_.advertise<visualization_msgs::MarkerArray>(
+      "local_path", 1, true);
+  full_trajectory_pub_ =
+      nh_private_.advertise<trajectory_msgs::MultiDOFJointTrajectory>(
+          "full_trajectory", 1, true);
+
+  // Services.
+  start_srv_ = nh_private_.advertiseService(
+      "start", &LocalPlannerNode::startCallback, this);
+  pause_srv_ = nh_private_.advertiseService(
+      "pause", &LocalPlannerNode::pauseCallback, this);
+  stop_srv_ = nh_private_.advertiseService(
+      "stop", &LocalPlannerNode::stopCallback, this);
+
+  // Start the command publishing spinner.
+  command_publishing_spinner_.start();
+}
+
+}  // namespace mav_planning

--- a/mav_local_planner/src/mav_local_planner_node.cpp
+++ b/mav_local_planner/src/mav_local_planner_node.cpp
@@ -1,0 +1,18 @@
+#include "mav_local_planner/mav_local_planner.h"
+
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "mav_local_planner");
+  google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
+
+  ros::NodeHandle nh("");
+  ros::NodeHandle nh_private("~");
+
+  FLAGS_alsologtostderr = true;
+
+  mav_planning::MavLocalPlanner node(nh, nh_private);
+  ROS_INFO("Initialized Mav Local Planner node.");
+
+  ros::spin();
+  return 0;
+}

--- a/mav_local_planner/worlds/maze_house.world
+++ b/mav_local_planner/worlds/maze_house.world
@@ -1,0 +1,1982 @@
+<?xml version="1.0" ?>
+<sdf version='1.6'>
+  <world name='default'>
+    <plugin name="ros_interface_plugin" filename="librotors_gazebo_ros_interface_plugin.so"/>
+    <physics type='ode'>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>1000</iters>
+          <sor>1.3</sor>
+        </solver>
+        <constraints>
+          <cfm>0</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>100</contact_max_correcting_vel>
+          <contact_surface_layer>0.001</contact_surface_layer>
+        </constraints>
+      </ode>
+      <max_step_size>0.01</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>100</real_time_update_rate>
+      <gravity>0 0 -9.8</gravity>
+    </physics>
+
+    <light name='sun' type='directional'>
+      <cast_shadows>1</cast_shadows>
+      <pose frame=''>0 0 10 0 -0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.1 0.1 0.1 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.5 -1</direction>
+    </light>
+    <model name='ground_plane'>
+      <static>1</static>
+      <link name='link'>
+        <collision name='collision'>
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>100</mu>
+                <mu2>50</mu2>
+              </ode>
+              <torsional>
+                <ode/>
+              </torsional>
+            </friction>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <cast_shadows>0</cast_shadows>
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+    </model>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type='adiabatic'/>
+
+    <scene>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>1</shadows>
+    </scene>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <latitude_deg>0</latitude_deg>
+      <longitude_deg>0</longitude_deg>
+      <elevation>0</elevation>
+      <heading_deg>0</heading_deg>
+    </spherical_coordinates>
+    <model name='Maze_House'>
+      <pose frame=''>-0.083649 -5.67478 0 0 -0 0</pose>
+      <link name='Wall_11'>
+        <collision name='Wall_11_Collision'>
+          <geometry>
+            <box>
+              <size>3.05 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_11_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3.05 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.996078 0.47451 0.0196078 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-5.47185 8.41758 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_12'>
+        <collision name='Wall_12_Collision'>
+          <geometry>
+            <box>
+              <size>2.25 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_12_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>2.25 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.996078 0.47451 0.0196078 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-4.03185 7.36758 0 0 0 -1.5708</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_14'>
+        <collision name='Wall_14_Collision'>
+          <geometry>
+            <box>
+              <size>2.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_14_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>2.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.996078 0.47451 0.0196078 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-5.91104 6.10678 0 0 0 -1.5708</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_16'>
+        <collision name='Wall_16_Collision'>
+          <geometry>
+            <box>
+              <size>2.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_16_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>2.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.996078 0.47451 0.0196078 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-8.48785 6.28957 0 0 -0 3.14159</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_18'>
+        <collision name='Wall_18_Collision'>
+          <geometry>
+            <box>
+              <size>2.5 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_18_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>2.5 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.996078 0.47451 0.0196078 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-8.54446 8.78539 0 0 0 -1.5708</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_20'>
+        <collision name='Wall_20_Collision'>
+          <geometry>
+            <box>
+              <size>2.5 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_20_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>2.5 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>1 0.764706 0.305882 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-2.69303 4.75396 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_22'>
+        <collision name='Wall_22_Collision'>
+          <geometry>
+            <box>
+              <size>3.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_22_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>1 0.764706 0.305882 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-0.505302 6.6178 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_24'>
+        <collision name='Wall_24_Collision'>
+          <geometry>
+            <box>
+              <size>4 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_24_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>4 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.333333 1 1 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>2.20732 2.72875 0 0 0 -1.5708</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_27'>
+        <collision name='Wall_27_Collision'>
+          <geometry>
+            <box>
+              <size>2 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_27_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>2 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>1 0.764706 0.305882 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-0.54846 8.59601 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_29'>
+        <collision name='Wall_29_Collision'>
+          <geometry>
+            <box>
+              <size>2.25 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_29_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>2.25 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>1 0.764706 0.305882 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>2.42857 8.89362 0 0 0 -1.5708</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_31'>
+        <collision name='Wall_31_Collision'>
+          <geometry>
+            <box>
+              <size>3.25 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_31_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3.25 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.333333 1 1 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>3.30334 5.74977 0 0 -0 0.785398</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_32'>
+        <collision name='Wall_32_Collision'>
+          <geometry>
+            <box>
+              <size>4 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_32_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>4 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.333333 1 1 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>6.32435 6.84578 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_34'>
+        <collision name='Wall_34_Collision'>
+          <geometry>
+            <box>
+              <size>3.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_34_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.333333 1 1 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>4.88243 2.43137 0 0 0 -1.5708</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_36'>
+        <collision name='Wall_36_Collision'>
+          <geometry>
+            <box>
+              <size>1.5 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_36_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.333333 1 1 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>6.18981 7.64181 0 0 -0 1.5708</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_39'>
+        <collision name='Wall_39_Collision'>
+          <geometry>
+            <box>
+              <size>2.25 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_39_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>2.25 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>1 0.764706 0.305882 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-3.86803 3.70396 0 0 0 -1.5708</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_40'>
+        <collision name='Wall_40_Collision'>
+          <geometry>
+            <box>
+              <size>3.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_40_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.996078 0.47451 0.0196078 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-5.66803 2.65396 0 0 -0 3.14159</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_42'>
+        <collision name='Wall_42_Collision'>
+          <geometry>
+            <box>
+              <size>4 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_42_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>4 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.996078 0.47451 0.0196078 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-7.94977 0.433564 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_44'>
+        <collision name='Wall_44_Collision'>
+          <geometry>
+            <box>
+              <size>6.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_44_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>6.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>1 0.764706 0.305882 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-3.86803 -0.646043 0 0 0 -1.5708</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_46'>
+        <collision name='Wall_46_Collision'>
+          <geometry>
+            <box>
+              <size>3.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_46_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.996078 0.47451 0.0196078 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-5.63157 -1.49524 0 0 -0 3.14159</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_50'>
+        <collision name='Wall_50_Collision'>
+          <geometry>
+            <box>
+              <size>4 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_50_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>4 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.996078 0.47451 0.0196078 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-7.9363 -3.64872 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_52'>
+        <collision name='Wall_52_Collision'>
+          <geometry>
+            <box>
+              <size>4 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_52_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>4 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>1 0.764706 0.305882 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-1.94303 -3.94604 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_54'>
+        <collision name='Wall_54_Collision'>
+          <geometry>
+            <box>
+              <size>8.5 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_54_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>8.5 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.996078 0.47451 0.0196078 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-5.74783 -6.10984 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_56'>
+        <collision name='Wall_56_Collision'>
+          <geometry>
+            <box>
+              <size>2 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_56_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>2 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.996078 0.47451 0.0196078 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-1.57283 -7.03484 0 0 0 -1.5708</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_58'>
+        <collision name='Wall_58_Collision'>
+          <geometry>
+            <box>
+              <size>15.1642 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_58_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>15.1642 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.333333 1 1 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>4.4541 -4.86797 0 0 0 -0.757292</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_6'>
+        <collision name='Wall_6_Collision'>
+          <geometry>
+            <box>
+              <size>20 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_6_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>20 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.435294 0.796078 0.67451 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-0.015512 10.075 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_61'>
+        <collision name='Wall_61_Collision'>
+          <geometry>
+            <box>
+              <size>2.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_61_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>2.75 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>1 0.764706 0.305882 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>0.889019 -4.89165 0 0 0 -0.785398</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_63'>
+        <collision name='Wall_63_Collision'>
+          <geometry>
+            <box>
+              <size>3.25 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_63_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3.25 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>1 0.764706 0.305882 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>4.77894 -8.94791 0 0 0 -0.785398</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_65'>
+        <collision name='Wall_65_Collision'>
+          <geometry>
+            <box>
+              <size>3 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_65_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.333333 1 1 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>5.26844 -4.26723 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_67'>
+        <collision name='Wall_67_Collision'>
+          <geometry>
+            <box>
+              <size>4 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_67_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>4 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.333333 1 1 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>7.96422 -1.27109 0 0 -0 3.14159</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_7'>
+        <collision name='Wall_7_Collision'>
+          <geometry>
+            <box>
+              <size>20.25 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_7_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>20.25 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.435294 0.796078 0.67451 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>9.90949 0.024991 0 0 0 -1.5708</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_8'>
+        <collision name='Wall_8_Collision'>
+          <geometry>
+            <box>
+              <size>20 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_8_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>20 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.435294 0.796078 0.67451 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-0.015512 -10.025 0 0 -0 3.14159</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <link name='Wall_9'>
+        <collision name='Wall_9_Collision'>
+          <geometry>
+            <box>
+              <size>20.25 0.15 2.5</size>
+            </box>
+          </geometry>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='Wall_9_Visual'>
+          <pose frame=''>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>20.25 0.15 2.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+            <ambient>0.435294 0.796078 0.67451 1</ambient>
+          </material>
+        </visual>
+        <pose frame=''>-9.94051 0.024991 0 0 -0 1.5708</pose>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+      <static>1</static>
+    </model>
+    <model name='unit_box_0'>
+      <pose frame=''>7.5152 -3.11588 0.5 0 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+    </model>
+    <state world_name='default'>
+      <sim_time>6844 228000000</sim_time>
+      <real_time>6858 150303292</real_time>
+      <wall_time>1540899424 599397415</wall_time>
+      <iterations>6844228</iterations>
+      <model name='Maze_House'>
+        <pose frame=''>-0.083649 -5.67478 0 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='Wall_11'>
+          <pose frame=''>-5.5555 2.7428 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_12'>
+          <pose frame=''>-4.1155 1.6928 0 0 0 -1.5708</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_14'>
+          <pose frame=''>-5.99469 0.432 0 0 0 -1.5708</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_16'>
+          <pose frame=''>-8.5715 0.61479 0 0 -0 3.14159</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_18'>
+          <pose frame=''>-8.62811 3.11061 0 0 0 -1.5708</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_20'>
+          <pose frame=''>-2.77668 -0.92082 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_22'>
+          <pose frame=''>-0.588951 0.94302 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_24'>
+          <pose frame=''>2.12367 -2.94603 0 0 0 -1.5708</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_27'>
+          <pose frame=''>-0.632109 2.92123 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_29'>
+          <pose frame=''>2.34492 3.21884 0 0 0 -1.5708</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_31'>
+          <pose frame=''>3.21969 0.07499 0 0 -0 0.785398</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_32'>
+          <pose frame=''>6.2407 1.171 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_34'>
+          <pose frame=''>4.79878 -3.24341 0 0 0 -1.5708</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_36'>
+          <pose frame=''>6.10616 1.96703 0 0 -0 1.5708</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_39'>
+          <pose frame=''>-3.95168 -1.97082 0 0 0 -1.5708</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_40'>
+          <pose frame=''>-5.75168 -3.02082 0 0 -0 3.14159</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_42'>
+          <pose frame=''>-8.03342 -5.24122 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_44'>
+          <pose frame=''>-3.95168 -6.32082 0 0 0 -1.5708</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_46'>
+          <pose frame=''>-5.71522 -7.17002 0 0 -0 3.14159</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_50'>
+          <pose frame=''>-8.01995 -9.3235 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_52'>
+          <pose frame=''>-2.02668 -9.62082 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_54'>
+          <pose frame=''>-5.83148 -11.7846 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_56'>
+          <pose frame=''>-1.65648 -12.7096 0 0 0 -1.5708</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_58'>
+          <pose frame=''>4.37045 -10.5427 0 0 0 -0.757292</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_6'>
+          <pose frame=''>-0.099161 4.40022 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_61'>
+          <pose frame=''>0.80537 -10.5664 0 0 0 -0.785398</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_63'>
+          <pose frame=''>4.69529 -14.6227 0 0 0 -0.785398</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_65'>
+          <pose frame=''>5.18479 -9.94201 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_67'>
+          <pose frame=''>7.88057 -6.94587 0 0 -0 3.14159</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_7'>
+          <pose frame=''>9.82584 -5.64979 0 0 0 -1.5708</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_8'>
+          <pose frame=''>-0.099161 -15.6998 0 0 -0 3.14159</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='Wall_9'>
+          <pose frame=''>-10.0242 -5.64979 0 0 -0 1.5708</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_plane'>
+        <pose frame=''>0 0 0 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose frame=''>0 0 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0'>
+        <pose frame=''>7.5152 -3.11588 0.5 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose frame=''>7.5152 -3.11588 0.5 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.004709 -9.78112 9.78158 0.712677 -0.009414 -4.3e-05</acceleration>
+          <wrench>-0.004709 -9.78112 9.78158 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone'>
+        <pose frame=''>-0.860078 2.13263 0.5 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose frame=''>-0.860078 2.13263 0.5 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_0'>
+        <pose frame=''>-6.9486 -4.16312 0.5 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose frame=''>-6.9486 -4.16312 0.5 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_1'>
+        <pose frame=''>-3.24754 -14.9576 0.5 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose frame=''>-3.24754 -14.9576 0.5 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_2'>
+        <pose frame=''>3.47911 -6.86951 0.5 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose frame=''>3.47911 -6.86951 0.5 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <light name='sun'>
+        <pose frame=''>0 0 10 0 -0 0</pose>
+      </light>
+    </state>
+    <model name='unit_box_0_clone'>
+      <pose frame=''>-0.860078 2.13263 0.5 0 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_0'>
+      <pose frame=''>-6.9486 -4.16312 0.5 0 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_1'>
+      <pose frame=''>-3.24754 -14.9576 0.5 0 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_2'>
+      <pose frame=''>3.47911 -6.86951 0.5 0 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <gravity>1</gravity>
+      </link>
+    </model>
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>-6.3846 -7.82833 34.6894 0 1.4978 -0.489903</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+  </world>
+</sdf>

--- a/mav_path_smoothing/include/mav_path_smoothing/loco_smoother.h
+++ b/mav_path_smoothing/include/mav_path_smoothing/loco_smoother.h
@@ -56,18 +56,7 @@ class LocoSmoother : public PolynomialSmoother {
 
  protected:
   double getMapDistanceAndGradient(const Eigen::VectorXd& position,
-                                   Eigen::VectorXd* gradient) const {
-    CHECK(distance_and_gradient_function_);
-    CHECK_EQ(position.size(), 3);
-    if (gradient == nullptr) {
-      return distance_and_gradient_function_(position, nullptr);
-    }
-    Eigen::Vector3d gradient_3d;
-    double distance = distance_and_gradient_function_(position, &gradient_3d);
-    *gradient = gradient_3d;
-    return distance;
-  }
-
+                                   Eigen::VectorXd* gradient) const;
   void resampleWaypointsFromVisibilityGraph(
       const mav_msgs::EigenTrajectoryPoint::Vector& waypoints,
       mav_msgs::EigenTrajectoryPoint::Vector* waypoints_out) const;

--- a/mav_path_smoothing/src/loco_smoother.cpp
+++ b/mav_path_smoothing/src/loco_smoother.cpp
@@ -191,4 +191,17 @@ void LocoSmoother::resampleWaypointsFromVisibilityGraph(
   waypoints_out->push_back(waypoints.back());
 }
 
+double LocoSmoother::getMapDistanceAndGradient(
+    const Eigen::VectorXd& position, Eigen::VectorXd* gradient) const {
+  CHECK(distance_and_gradient_function_);
+  CHECK_EQ(position.size(), 3);
+  if (gradient == nullptr) {
+    return distance_and_gradient_function_(position, nullptr);
+  }
+  Eigen::Vector3d gradient_3d;
+  double distance = distance_and_gradient_function_(position, &gradient_3d);
+  *gradient = gradient_3d;
+  return distance;
+}
+
 }  // namespace mav_planning

--- a/mav_planning_benchmark/CMakeLists.txt
+++ b/mav_planning_benchmark/CMakeLists.txt
@@ -11,6 +11,7 @@ add_definitions(-std=c++11)
 #############
 cs_add_library(${PROJECT_NAME}
   src/global_planning_benchmark.cpp
+  src/local_planning_benchmark.cpp
 )
 
 ############

--- a/mav_planning_benchmark/CMakeLists.txt
+++ b/mav_planning_benchmark/CMakeLists.txt
@@ -22,6 +22,11 @@ cs_add_executable(global_planning_benchmark_node
 )
 target_link_libraries(global_planning_benchmark_node ${PROJECT_NAME})
 
+cs_add_executable(local_planning_benchmark_node
+  src/local_planning_benchmark_node.cpp
+)
+target_link_libraries(local_planning_benchmark_node ${PROJECT_NAME})
+
 ##########
 # EXPORT #
 ##########

--- a/mav_planning_benchmark/include/mav_planning_benchmark/local_planning_benchmark.h
+++ b/mav_planning_benchmark/include/mav_planning_benchmark/local_planning_benchmark.h
@@ -4,6 +4,7 @@
 #include <mav_msgs/eigen_mav_msgs.h>
 #include <mav_planning_common/physical_constraints.h>
 #include <voxblox/simulation/simulation_world.h>
+#include <voxblox_loco_planner/voxblox_loco_planner.h>
 #include <voxblox_ros/esdf_server.h>
 
 namespace mav_planning {
@@ -59,6 +60,14 @@ class LocalPlanningBenchmark {
       const mav_msgs::EigenTrajectoryPointVector& path) const;
   bool isPathFeasible(const mav_msgs::EigenTrajectoryPointVector& path) const;
 
+  // Visualization helpers.
+  void appendViewpointMarker(
+      const mav_msgs::EigenTrajectoryPoint& point,
+      visualization_msgs::MarkerArray* marker_array) const;
+
+  // Path helpers.
+  void setYawFromVelocity(double default_yaw,
+                          mav_msgs::EigenTrajectoryPointVector* path);
   /*
   // Functions to actually run the planners.
 
@@ -91,6 +100,10 @@ class LocalPlanningBenchmark {
   bool visualize_;
   std::string frame_id_;
 
+  // Planning settings.
+  double replan_dt_;
+  int max_replans_;
+
   // Map settings.
   Eigen::Vector3d lower_bound_;
   Eigen::Vector3d upper_bound_;
@@ -113,6 +126,7 @@ class LocalPlanningBenchmark {
   voxblox::SimulationWorld world_;
 
   // Planners will go here!
+  VoxbloxLocoPlanner loco_planner_;
 
   // Which methods to use.
   std::vector<LocalPlanningMethod> local_planning_methods_;

--- a/mav_planning_benchmark/include/mav_planning_benchmark/local_planning_benchmark.h
+++ b/mav_planning_benchmark/include/mav_planning_benchmark/local_planning_benchmark.h
@@ -1,0 +1,122 @@
+#ifndef MAV_PLANNING_BENCHMKARK_LOCAL_PLANNING_BENCHMARK_H_
+#define MAV_PLANNING_BENCHMKARK_LOCAL_PLANNING_BENCHMARK_H_
+
+#include <mav_planning_common/physical_constraints.h>
+#include <voxblox_ros/esdf_server.h>
+
+namespace mav_planning {
+
+class LocalPlanningBenchmark {
+ public:
+  enum LocalPlanningMethod { kStraightLine = 0 };
+
+  enum PathSmoothingMethod { kNone = 0, kVelocityRamp, kPolynomial, kLoco };
+  struct LocalBenchmarkResult {
+    int trial_number = 0;
+    int seed = 0;
+    double density = 0.0;
+    double robot_radius_m = 0.0;
+    double v_max = 0.0;
+    double a_max = 0.0;
+    LocalPlanningMethod local_planning_method;
+    bool planning_success = false;
+    bool is_collision_free = false;
+    bool is_feasible = false;
+    int num_replans = 0;
+    double distance_from_goal = 0.0;
+    double computation_time_sec = 0.0;
+    double total_path_time_sec = 0.0;
+    double total_path_length_m = 0.0;
+    double straight_line_path_length_m = 0.0;
+  };
+
+  LocalPlanningBenchmark(const ros::NodeHandle& nh,
+                         const ros::NodeHandle& nh_private);
+
+  // General trajectory benchmark tools: call these in order.
+  void generateWorld(double density);
+  void runBenchmark(int trial_number);
+  void outputResults(const std::string& filename);
+
+  // Accessors.
+  bool visualize() const { return visualize_; }
+
+ private:
+  void setupPlanners();
+
+  void generateCustomWorld(const Eigen::Vector3d& size, double density);
+  // Generates a synthetic viewpoint, and adds it to the voxblox map.
+  void addViewpointToMap(const mav_msgs::EigenTrajectoryPoint& viewpoint);
+
+  double getMapDistance(const Eigen::Vector3d& position) const;
+  double getMapDistanceWithoutInterpolation(
+      const Eigen::Vector3d& position) const;
+  double getMapDistanceAndGradient(const Eigen::Vector3d& position,
+                                   Eigen::Vector3d* gradient) const;
+
+  // Evaluate what we've got here.
+  bool isPathCollisionFree(
+      const mav_msgs::EigenTrajectoryPointVector& path) const;
+  bool isPathFeasible(const mav_msgs::EigenTrajectoryPointVector& path) const;
+
+  /*
+  // Functions to actually run the planners.
+
+  void fillInPathResults(const mav_msgs::EigenTrajectoryPointVector& path,
+                         GlobalBenchmarkResult* result) const;
+
+  bool runGlobalPlanner(const GlobalPlanningMethod planning_method,
+                        const mav_msgs::EigenTrajectoryPoint& start,
+                        const mav_msgs::EigenTrajectoryPoint& goal,
+                        mav_msgs::EigenTrajectoryPointVector* waypoints);
+  bool runPathSmoother(const PathSmoothingMethod smoothing_method,
+                       const mav_msgs::EigenTrajectoryPointVector& waypoints,
+                       mav_msgs::EigenTrajectoryPointVector* path);
+
+                       */
+
+  ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
+
+  // ROS stuff.
+  ros::Publisher path_marker_pub_;
+  ros::Publisher view_ptcloud_pub_;
+  ros::Publisher additional_marker_pub_;
+
+  // Settings for physical constriants.
+  PhysicalConstraints constraints_;
+
+  // General settings.
+  bool verbose_;
+  bool visualize_;
+  std::string frame_id_;
+
+  // Map settings.
+  Eigen::Vector3d lower_bound_;
+  Eigen::Vector3d upper_bound_;
+
+  // Camera parameters for both the NBVP (and other) camera simulations and
+  // the camera simulation with the voxblox sim world.
+  Eigen::Vector2i camera_resolution_;
+  double camera_fov_h_rad_;
+  double camera_min_dist_;
+  double camera_max_dist_;
+  // Optionally use a different max distance for the cam model vs. the actual
+  // simulation.
+  double camera_model_dist_;
+
+  // Voxblox Server!
+  std::unique_ptr<voxblox::EsdfServer> esdf_server_;
+
+  // Planners will go here!
+
+  // Which methods to use.
+  std::vector<LocalPlanningMethod> local_planning_methods_;
+
+  // Results.
+  std::vector<LocalBenchmarkResult> results_;
+};
+
+}  // namespace mav_planning
+
+#endif  // MAV_PLANNING_BENCHMKARK_LOCAL_PLANNING_BENCHMARK_H_

--- a/mav_planning_benchmark/include/mav_planning_benchmark/local_planning_benchmark.h
+++ b/mav_planning_benchmark/include/mav_planning_benchmark/local_planning_benchmark.h
@@ -11,7 +11,7 @@ namespace mav_planning {
 
 class LocalPlanningBenchmark {
  public:
-  enum LocalPlanningMethod { kStraightLine = 0, kLoco};
+  enum LocalPlanningMethod { kStraightLine = 0, kLoco };
 
   struct LocalBenchmarkResult {
     int trial_number = 0;

--- a/mav_planning_benchmark/include/mav_planning_benchmark/local_planning_benchmark.h
+++ b/mav_planning_benchmark/include/mav_planning_benchmark/local_planning_benchmark.h
@@ -51,8 +51,6 @@ class LocalPlanningBenchmark {
   void addViewpointToMap(const mav_msgs::EigenTrajectoryPoint& viewpoint);
 
   double getMapDistance(const Eigen::Vector3d& position) const;
-  double getMapDistanceWithoutInterpolation(
-      const Eigen::Vector3d& position) const;
   double getMapDistanceAndGradient(const Eigen::Vector3d& position,
                                    Eigen::Vector3d* gradient) const;
 

--- a/mav_planning_benchmark/include/mav_planning_benchmark/local_planning_benchmark.h
+++ b/mav_planning_benchmark/include/mav_planning_benchmark/local_planning_benchmark.h
@@ -1,7 +1,9 @@
 #ifndef MAV_PLANNING_BENCHMKARK_LOCAL_PLANNING_BENCHMARK_H_
 #define MAV_PLANNING_BENCHMKARK_LOCAL_PLANNING_BENCHMARK_H_
 
+#include <mav_msgs/eigen_mav_msgs.h>
 #include <mav_planning_common/physical_constraints.h>
+#include <voxblox/simulation/simulation_world.h>
 #include <voxblox_ros/esdf_server.h>
 
 namespace mav_planning {
@@ -104,9 +106,13 @@ class LocalPlanningBenchmark {
   // Optionally use a different max distance for the cam model vs. the actual
   // simulation.
   double camera_model_dist_;
+  // Cached.
+  double voxel_size_;
+  double density_;
 
   // Voxblox Server!
-  std::unique_ptr<voxblox::EsdfServer> esdf_server_;
+  voxblox::EsdfServer esdf_server_;
+  voxblox::SimulationWorld world_;
 
   // Planners will go here!
 

--- a/mav_planning_benchmark/include/mav_planning_benchmark/local_planning_benchmark.h
+++ b/mav_planning_benchmark/include/mav_planning_benchmark/local_planning_benchmark.h
@@ -11,9 +11,8 @@ namespace mav_planning {
 
 class LocalPlanningBenchmark {
  public:
-  enum LocalPlanningMethod { kStraightLine = 0 };
+  enum LocalPlanningMethod { kStraightLine = 0, kLoco};
 
-  enum PathSmoothingMethod { kNone = 0, kVelocityRamp, kPolynomial, kLoco };
   struct LocalBenchmarkResult {
     int trial_number = 0;
     int seed = 0;

--- a/mav_planning_benchmark/launch/local_planning_benchmark.launch
+++ b/mav_planning_benchmark/launch/local_planning_benchmark.launch
@@ -8,11 +8,14 @@
 
     <param name="visualize" value="true" />
     <param name="robot_radius" value="0.5" />
-    <param name="tsdf_voxel_size" value="0.15" />
+    <param name="tsdf_voxel_size" value="0.10" />
     <param name="tsdf_voxels_per_side" value="16" />
-    <param name="clear_sphere_radius" value="1.0" />
+    <param name="clear_sphere_radius" value="1.5" />
+    <param name="occupied_sphere_radius" value="4.0" />
     <param name="update_mesh_every_n_sec" value="0.0" />
     <param name="num_seconds_to_plan" value="5.0" />
+    <param name="camera_max_dist" value="20.0" />
+    <param name="max_ray_length_m" value="5.0" />
     <param name="frame_id" value="$(arg frame_id)" />
     <param name="world_frame" value="$(arg frame_id)" />
     <param name="publish_pointclouds" value="true" />

--- a/mav_planning_benchmark/launch/local_planning_benchmark.launch
+++ b/mav_planning_benchmark/launch/local_planning_benchmark.launch
@@ -1,0 +1,23 @@
+<launch>
+  <arg name="results_path" default="/home/helen/data/jfr_2018/local_benchmark/first_23_10_2018.csv" />
+
+  <arg name="frame_id" default="odom" />
+
+  <node name="local_planning_benchmark" pkg="mav_planning_benchmark" type="local_planning_benchmark_node" output="screen" args="--alsologtostderr">
+    <param name="results_path" value="$(arg results_path)" />
+
+    <param name="visualize" value="true" />
+    <param name="robot_radius" value="0.5" />
+    <param name="tsdf_voxel_size" value="0.15" />
+    <param name="tsdf_voxels_per_side" value="16" />
+    <param name="clear_sphere_radius" value="1.0" />
+    <param name="update_mesh_every_n_sec" value="0.0" />
+    <param name="num_seconds_to_plan" value="5.0" />
+    <param name="frame_id" value="$(arg frame_id)" />
+    <param name="world_frame" value="$(arg frame_id)" />
+    <param name="publish_pointclouds" value="true" />
+    <param name="verbose" value="true" />
+
+  </node>
+
+</launch>

--- a/mav_planning_benchmark/launch/local_planning_benchmark.launch
+++ b/mav_planning_benchmark/launch/local_planning_benchmark.launch
@@ -1,14 +1,14 @@
 <launch>
-  <arg name="results_path" default="/home/helen/data/jfr_2018/local_benchmark/first_23_10_2018.csv" />
+  <arg name="results_path" default="/home/helen/data/jfr_2018/local_benchmark/local_23_10_2018.csv" />
 
   <arg name="frame_id" default="odom" />
 
   <node name="local_planning_benchmark" pkg="mav_planning_benchmark" type="local_planning_benchmark_node" output="screen" args="--alsologtostderr">
     <param name="results_path" value="$(arg results_path)" />
 
-    <param name="visualize" value="true" />
+    <param name="visualize" value="false" />
     <param name="robot_radius" value="0.5" />
-    <param name="tsdf_voxel_size" value="0.10" />
+    <param name="tsdf_voxel_size" value="0.15" />
     <param name="tsdf_voxels_per_side" value="16" />
     <param name="clear_sphere_radius" value="1.5" />
     <param name="occupied_sphere_radius" value="4.0" />

--- a/mav_planning_benchmark/launch/local_planning_benchmark.launch
+++ b/mav_planning_benchmark/launch/local_planning_benchmark.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="results_path" default="/home/helen/data/jfr_2018/local_benchmark/local_23_10_2018.csv" />
+  <arg name="results_path" default="/home/helen/data/jfr_2018/local_benchmark/local_24_10_2018_continue.csv" />
 
   <arg name="frame_id" default="odom" />
 
@@ -8,7 +8,7 @@
 
     <param name="visualize" value="false" />
     <param name="robot_radius" value="0.5" />
-    <param name="tsdf_voxel_size" value="0.15" />
+    <param name="tsdf_voxel_size" value="0.20" />
     <param name="tsdf_voxels_per_side" value="16" />
     <param name="clear_sphere_radius" value="1.5" />
     <param name="occupied_sphere_radius" value="4.0" />

--- a/mav_planning_benchmark/package.xml
+++ b/mav_planning_benchmark/package.xml
@@ -14,13 +14,14 @@
   <buildtool_depend>catkin_simple</buildtool_depend>
 
   <depend>mav_msgs</depend>
-  <depend>mav_trajectory_generation_ros</depend>
   <depend>mav_planning_common</depend>
+  <depend>mav_trajectory_generation_ros</depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
   <depend>tf</depend>
+  <depend>visualization_msgs</depend>
+  <depend>voxblox_loco_planner</depend>
+  <depend>voxblox_ros</depend>
   <depend>voxblox_rrt_planner</depend>
   <depend>voxblox_skeleton_planner</depend>
-  <depend>visualization_msgs</depend>
-  <depend>voxblox_ros</depend>
 </package>

--- a/mav_planning_benchmark/src/local_planning_benchmark.cpp
+++ b/mav_planning_benchmark/src/local_planning_benchmark.cpp
@@ -1,0 +1,226 @@
+#include <voxblox/core/common.h>
+
+#include "mav_planning_benchmark/local_planning_benchmark.h"
+
+namespace mav_planning {
+
+LocalPlanningBenchmark::LocalPlanningBenchmark(
+    const ros::NodeHandle& nh, const ros::NodeHandle& nh_private)
+    : nh_(nh),
+      nh_private_(nh_private),
+      visualize_(true),
+      frame_id_("map"),
+      lower_bound_(2.5, 0.0, 0.0),
+      upper_bound_(12.5, 10.0, 5.0),
+      camera_resolution_(320, 240),
+      camera_fov_h_rad_(1.5708),  // 90 deg
+      camera_min_dist_(0.5),
+      camera_max_dist_(10.0),
+      camera_model_dist_(5.0) {
+  constraints_.setParametersFromRos(nh_private_);
+
+  nh_private_.param("visualize", visualize_, visualize_);
+  nh_private_.param("frame_id", frame_id_, frame_id_);
+
+  nh_private_.param("camera_max_dist", camera_max_dist_, camera_max_dist_);
+  nh_private_.param("camera_model_dist", camera_model_dist_,
+                    camera_model_dist_);
+
+  path_marker_pub_ =
+      nh_private_.advertise<visualization_msgs::MarkerArray>("path", 1, true);
+  view_ptcloud_pub_ = nh_private_.advertise<pcl::PointCloud<pcl::PointXYZRGB> >(
+      "view_ptcloud_pub", 1, true);
+  additional_marker_pub_ =
+      nh_private_.advertise<visualization_msgs::MarkerArray>("path_additions",
+                                                             1, true);
+
+  voxblox_server_.setClearSphere(true);
+}
+
+void LocalPlanningBenchmark::generateWorld(double density) {
+  const double kWorldXY = 10.0;
+  const double kWorldZ = 5.0;
+
+  generateCustomWorld(Eigen::Vector3d(kWorldXY, kWorldXY, kWorldZ), density);
+}
+
+void LocalPlanningBenchmark::runBenchmark(int trial_number) {}
+
+void LocalPlanningBenchmark::outputResults(const std::string& filename) {
+  FILE* fp = fopen(filename.c_str(), "w+");
+  if (fp == NULL) {
+    return;
+  }
+  fprintf(fp,
+          "#trial,seed,density,robot_radius,v_max,a_max,local_method,planning_"
+          "success,is_collision_free,is_feasible,num_replans,distance_from_"
+          "goal,computation_time_sec,total_path_time_sec,total_path_length_m,"
+          "straight_line_path_length_m\n");
+  for (const GlobalBenchmarkResult& result : results_) {
+    fprintf(fp, "%d,%d,%f,%f,%f,%f,%d,%d,%d,%d,%d,%f,%f,%f,%f,%f\n",
+            result.trial_number, result.seed, result.density,
+            result.robot_radius_m, result.v_max, result.a_max,
+            result.local_planning_method, result.planning_success,
+            result.is_collision_free, result.is_feasible, result.num_replans,
+            result.distance_from_goal, result.computation_time_sec,
+            result.total_path_time_sec, result.total_path_length_m,
+            result.straight_line_path_length_m);
+  }
+  fclose(fp);
+  ROS_INFO_STREAM("[Local Planning Benchmark] Output results to: " << filename);
+}
+
+void LocalPlanningBenchmark::generateCustomWorld(const Eigen::Vector3d& size,
+                                                 double density) {
+  voxblox_server_.clear();
+
+  density_ = density;  // Cache this for result output.
+  world_.clear();
+  world_.addPlaneBoundaries(0.0, size.x(), 0.0, size.y());
+  world_.addGroundLevel(0.0);
+  // Sets the display bounds.
+  world_.setBounds(
+      Eigen::Vector3f(-1.0, -1.0, -1.0),
+      size.cast<voxblox::FloatingPoint>() + Eigen::Vector3f(1.0, 1.0, 1.0));
+
+  // Free space around the edges (so we know we don't start in collision).
+  Eigen::Vector3d free_space_bounds(2.0, 2.0, 2.0);
+
+  // Some mins and maxes... All objects gotta be on the floor. Just because.
+  const double kMinHeight = 2.0;
+  const double kMaxHeight = 5.0;
+  const double kMinRadius = 0.25;
+  const double kMaxRadius = 1.0;
+
+  double usable_area = size.x() * size.y();
+  int num_objects = static_cast<int>(std::floor(density * usable_area));
+
+  for (int i = 0; i < num_objects; ++i) {
+    // First select size; pose depends on size in z.
+    double height = randMToN(kMinHeight, kMaxHeight);
+    double radius = randMToN(kMinRadius, kMaxRadius);
+    // First select its pose.
+    Eigen::Vector3d position(
+        randMToN(free_space_bounds.x(), size.x() - free_space_bounds.x()),
+        randMToN(free_space_bounds.y(), size.y() - free_space_bounds.y()),
+        height / 2.0);
+
+    world_.addObject(std::unique_ptr<voxblox::Object>(new voxblox::Cylinder(
+        position.cast<float>(), radius, height, voxblox::Color::Gray())));
+  }
+
+  voxblox_server_.setSliceLevel(1.5);
+
+  // Cache the TSDF voxel size.
+  voxel_size_ =
+      voxblox_server_.getTsdfMapPtr()->getTsdfLayerPtr()->voxel_size();
+}
+
+// Generates a synthetic viewpoint, and adds it to the voxblox map.
+void LocalPlanningBenchmark::addViewpointToMap(
+    const mav_msgs::EigenTrajectoryPoint& viewpoint) {
+  // Step 1: get the T_G_C for this viewpoint, and view origin + direction.
+  // The yaw direction is now just coming from the trajectory, as the yaw
+  // is assigned earlier for the whole trajectory chunk now.
+  Eigen::Vector3f view_origin = viewpoint.position_W.cast<float>();
+  Eigen::Vector3f view_direction(1.0, 0.0, 0.0);
+  view_direction = viewpoint.orientation_W_B.cast<float>() * view_direction;
+
+  // T_G_C is from z-positive since that's how camera coordinates work.
+  voxblox::Transformation T_G_C(
+      view_origin.cast<float>(),
+      Eigen::Quaternionf::FromTwoVectors(Eigen::Vector3f(0.0, 0.0, 1.0),
+                                         view_direction));
+  // Step 2: actually get the pointcloud.
+  voxblox::Pointcloud ptcloud, ptcloud_C;
+  voxblox::Colors colors;
+  world_.getPointcloudFromViewpoint(view_origin, view_direction,
+                                    camera_resolution_, camera_fov_h_rad_,
+                                    camera_max_dist_, &ptcloud, &colors);
+
+  // Step 3: integrate into the map.
+  // Transform back into camera frame.
+  voxblox::transformPointcloud(T_G_C.inverse(), ptcloud, &ptcloud_C);
+  voxblox_server_.integratePointcloud(T_G_C, ptcloud_C, colors);
+
+  // Step 4: update mesh and ESDF. NewPoseCallback will mark unknown as
+  // occupied and clear space otherwise.
+  voxblox_server_.newPoseCallback(T_G_C);
+  if (visualize_) {
+    voxblox_server_.updateMesh();
+  } else {
+    voxblox_server_.updateEsdf();
+  }
+
+  if (visualize_) {
+    voxblox_server_.publishAllUpdatedTsdfVoxels();
+    voxblox_server_.publishSlices();
+
+    pcl::PointCloud<pcl::PointXYZRGB> ptcloud_pcl;
+    ptcloud_pcl.header.frame_id = frame_id_;
+    for (size_t i = 0; i < ptcloud.size(); ++i) {
+      pcl::PointXYZRGB point;
+      point.x = ptcloud[i].x();
+      point.y = ptcloud[i].y();
+      point.z = ptcloud[i].z();
+      point.r = colors[i].r;
+      point.g = colors[i].g;
+      point.b = colors[i].b;
+      ptcloud_pcl.push_back(point);
+    }
+
+    view_ptcloud_pub_.publish(ptcloud_pcl);
+  }
+}
+
+double LocalPlanningBenchmark::getMapDistance(
+    const Eigen::Vector3d& position) const {
+  CHECK(esdf_server_);
+  double distance = 0.0;
+  const bool kInterpolate = false;
+  if (!esdf_server_->getEsdfMapPtr()->getDistanceAtPosition(
+          position, kInterpolate, &distance)) {
+    return 0.0;
+  }
+  return distance;
+}
+
+double LocalPlanningBenchmark::getMapDistanceAndGradient(
+    const Eigen::Vector3d& position, Eigen::Vector3d* gradient) const {
+  CHECK(esdf_server_);
+  double distance = 0.0;
+  const bool kInterpolate = false;
+  if (!esdf_server_->getEsdfMapPtr()->getDistanceAndGradientAtPosition(
+          position, kInterpolate, &distance, gradient)) {
+    return 0.0;
+  }
+  return distance;
+}
+
+// Evaluate what we've got here.
+bool LocalPlanningBenchmark::isPathCollisionFree(
+    const mav_msgs::EigenTrajectoryPointVector& path) const {
+  for (const mav_msgs::EigenTrajectoryPoint& point : path) {
+    if (getMapDistance(point.position_W) < constraints_.robot_radius) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool LocalPlanningBenchmark::isPathFeasible(
+    const mav_msgs::EigenTrajectoryPointVector& path) const {
+  // This is easier to check in the trajectory but then we are limited in how
+  // we do the smoothing.
+  for (const mav_msgs::EigenTrajectoryPoint& point : path) {
+    if (point.acceleration_W.norm() > constraints_.a_max + 1e-2) {
+      return false;
+    }
+    if (point.velocity_W.norm() > constraints_.v_max + 1e-2) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace mav_planning

--- a/mav_planning_benchmark/src/local_planning_benchmark.cpp
+++ b/mav_planning_benchmark/src/local_planning_benchmark.cpp
@@ -206,6 +206,7 @@ void LocalPlanningBenchmark::runBenchmark(int trial_number) {
       constraints_.sampling_dt * executed_path.size();
   result_template.is_collision_free = isPathCollisionFree(executed_path);
   result_template.is_feasible = isPathFeasible(executed_path);
+  result_template.local_planning_method = kLoco;
 
   results_.push_back(result_template);
   ROS_INFO(
@@ -348,7 +349,7 @@ void LocalPlanningBenchmark::addViewpointToMap(
 double LocalPlanningBenchmark::getMapDistance(
     const Eigen::Vector3d& position) const {
   double distance = 0.0;
-  const bool kInterpolate = false;
+  const bool kInterpolate = true;
   if (!esdf_server_.getEsdfMapPtr()->getDistanceAtPosition(
           position, kInterpolate, &distance)) {
     return 0.0;
@@ -359,7 +360,7 @@ double LocalPlanningBenchmark::getMapDistance(
 double LocalPlanningBenchmark::getMapDistanceAndGradient(
     const Eigen::Vector3d& position, Eigen::Vector3d* gradient) const {
   double distance = 0.0;
-  const bool kInterpolate = false;
+  const bool kInterpolate = true;
   if (!esdf_server_.getEsdfMapPtr()->getDistanceAndGradientAtPosition(
           position, kInterpolate, &distance, gradient)) {
     return 0.0;

--- a/mav_planning_benchmark/src/local_planning_benchmark.cpp
+++ b/mav_planning_benchmark/src/local_planning_benchmark.cpp
@@ -73,9 +73,14 @@ void LocalPlanningBenchmark::runBenchmark(int trial_number) {
   result_template.a_max = constraints_.a_max;
 
   mav_msgs::EigenTrajectoryPoint start, goal;
-  start.position_W = Eigen::Vector3d(1.0, 1.0, kPlanningHeight);
+  start.position_W =
+      Eigen::Vector3d(1.0, upper_bound_.y() / 2.0, kPlanningHeight);
   goal.position_W = upper_bound_ - start.position_W;
   goal.position_W.z() = kPlanningHeight;
+
+  ROS_INFO_STREAM("Start: " << start.position_W.transpose()
+                            << " Goal: " << goal.position_W.transpose());
+
   start.setFromYaw(0.0);
   goal.setFromYaw(0.0);
   result_template.straight_line_path_length_m =
@@ -248,7 +253,7 @@ void LocalPlanningBenchmark::generateCustomWorld(const Eigen::Vector3d& size,
       size.cast<voxblox::FloatingPoint>() + Eigen::Vector3f(1.0, 1.0, 1.0));
 
   // Free space around the edges (so we know we don't start in collision).
-  Eigen::Vector3d free_space_bounds(2.0, 2.0, 2.0);
+  Eigen::Vector3d free_space_bounds(4.0, 4.0, 4.0);
 
   // Some mins and maxes... All objects gotta be on the floor. Just because.
   const double kMinHeight = 2.0;

--- a/mav_planning_benchmark/src/local_planning_benchmark_node.cpp
+++ b/mav_planning_benchmark/src/local_planning_benchmark_node.cpp
@@ -13,13 +13,13 @@ int main(int argc, char** argv) {
   mav_planning::LocalPlanningBenchmark node(nh, nh_private);
   ROS_INFO("Initialized local planning benchmark node.");
 
-  int num_trials = 1;
+  int num_trials = 100;
   std::string results_path;
   nh_private.param("results_path", results_path, results_path);
   nh_private.param("num_trials", num_trials, num_trials);
 
   const double min_density = 0.05;
-  const double max_density = 0.05;
+  const double max_density = 0.50;
   const double density_increment = 0.05;
 
   // Derived...

--- a/mav_planning_benchmark/src/local_planning_benchmark_node.cpp
+++ b/mav_planning_benchmark/src/local_planning_benchmark_node.cpp
@@ -13,13 +13,14 @@ int main(int argc, char** argv) {
   mav_planning::LocalPlanningBenchmark node(nh, nh_private);
   ROS_INFO("Initialized local planning benchmark node.");
 
-  int num_trials = 1;
+  int num_trials = 5;
   std::string results_path;
   nh_private.param("results_path", results_path, results_path);
   nh_private.param("num_trials", num_trials, num_trials);
 
-  double density = 0.1;
+  double density = 0.10;
   for (int i = 0; i < num_trials; i++) {
+    srand(i);
     node.generateWorld(density);
     node.runBenchmark(i);
   }

--- a/mav_planning_benchmark/src/local_planning_benchmark_node.cpp
+++ b/mav_planning_benchmark/src/local_planning_benchmark_node.cpp
@@ -1,0 +1,37 @@
+#include "mav_planning_benchmark/local_planning_benchmark.h"
+
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "local_planning_benchmark");
+  google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
+
+  ros::NodeHandle nh("");
+  ros::NodeHandle nh_private("~");
+
+  FLAGS_alsologtostderr = true;
+
+  mav_planning::LocalPlanningBenchmark node(nh, nh_private);
+  ROS_INFO("Initialized local planning benchmark node.");
+
+  int num_trials = 1;
+  std::string results_path;
+  nh_private.param("results_path", results_path, results_path);
+  nh_private.param("num_trials", num_trials, num_trials);
+
+  double density = 0.1;
+  for (int i = 0; i < num_trials; i++) {
+    node.generateWorld(density);
+    node.runBenchmark(i);
+  }
+
+  if (!results_path.empty()) {
+    node.outputResults(results_path);
+  }
+
+  ROS_INFO_STREAM("All timings: "
+                  << std::endl
+                  << mav_trajectory_generation::timing::Timing::Print());
+
+  ros::spin();
+  return 0;
+}

--- a/mav_planning_common/CMakeLists.txt
+++ b/mav_planning_common/CMakeLists.txt
@@ -4,6 +4,7 @@ project(mav_planning_common)
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
+add_definitions(-std=c++11 -Wall)
 
 #############
 # LIBRARIES #

--- a/mav_planning_common/CMakeLists.txt
+++ b/mav_planning_common/CMakeLists.txt
@@ -12,6 +12,7 @@ add_definitions(-std=c++11 -Wall)
 cs_add_library(${PROJECT_NAME}
   src/color_utils.cpp
   src/path_visualization.cpp
+  src/yaw_policy.cpp
 )
 
 ##########

--- a/mav_planning_common/include/mav_planning_common/path_utils.h
+++ b/mav_planning_common/include/mav_planning_common/path_utils.h
@@ -27,6 +27,17 @@ inline void retimeTrajectoryMonotonicallyIncreasing(
   }
 }
 
+inline void retimeTrajectoryWithStartTimeAndDt(
+    int64_t start_time_ns, int64_t dt_ns,
+    mav_msgs::EigenTrajectoryPointVector* trajectory) {
+  int64_t current_time_ns = start_time_ns;
+
+  for (size_t i = 0; i < trajectory->size(); ++i) {
+    (*trajectory)[i].time_from_start_ns = current_time_ns;
+    current_time_ns += dt_ns;
+  }
+}
+
 }  // namespace mav_planning
 
 #endif  // MAV_PLANNING_COMMON_PATH_UTILS_H_

--- a/mav_planning_common/include/mav_planning_common/semaphore.h
+++ b/mav_planning_common/include/mav_planning_common/semaphore.h
@@ -1,0 +1,44 @@
+#ifndef MAV_PLANNING_COMMON_SEMAPHORE_H_
+#define MAV_PLANNING_COMMON_SEMAPHORE_H_
+
+#include <ros/ros.h>
+#include <condition_variable>
+#include <mutex>
+
+namespace mav_planning {
+
+// A simple semaphore, taken from StackOverflow:
+// https://stackoverflow.com/questions/4792449/c0x-has-no-semaphores-how-to-synchronize-threads
+// All credit to Tsuneo Yoshioka.
+class RosSemaphore {
+ public:
+  RosSemaphore(int count = 0) : count_(count) {}
+
+  inline void notify() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    count_++;
+    cv_.notify_one();
+  }
+
+  inline bool wait_for(double sec) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!cv_.wait_for(lock, std::chrono::duration<double>(sec),
+                      [this]() { return count_ > 0 || !ros::ok(); })) {
+      return false;
+    }
+    if (count_ > 0) {
+      count_--;
+      return true;
+    }
+    return false;
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  int count_;
+};
+
+}  // namespace mav_planning
+
+#endif  // MAV_PLANNING_COMMON_SEMAPHORE_H_

--- a/mav_planning_common/include/mav_planning_common/utils.h
+++ b/mav_planning_common/include/mav_planning_common/utils.h
@@ -11,7 +11,7 @@ inline double computePathLength(
     const mav_msgs::EigenTrajectoryPointVector& path) {
   Eigen::Vector3d last_point;
   double distance = 0;
-  for (int i = 0; i < path.size(); ++i) {
+  for (size_t i = 0; i < path.size(); ++i) {
     const mav_msgs::EigenTrajectoryPoint& point = path[i];
 
     if (i > 0) {

--- a/mav_planning_common/include/mav_planning_common/yaw_policy.h
+++ b/mav_planning_common/include/mav_planning_common/yaw_policy.h
@@ -39,14 +39,6 @@ class YawPolicy {
   void applyPolicy(const mav_msgs::EigenTrajectoryPointVector& path_in,
                    mav_msgs::EigenTrajectoryPointVector* path_out);
 
-  void applyPolicyInPlace(double initial_yaw,
-                          mav_msgs::EigenTrajectoryPointVector* path,
-                          bool initial_yaw_given = true);
-  void applyPolicy(const mav_msgs::EigenTrajectoryPointVector& path_in,
-                   double initial_yaw,
-                   mav_msgs::EigenTrajectoryPointVector* path_out,
-                   bool initial_yaw_given = true);
-
   void setFacingPoint(const Eigen::Vector3d& point) { facing_point_ = point; }
   Eigen::Vector3d getFacingPoint() const { return facing_point_; }
 

--- a/mav_planning_common/include/mav_planning_common/yaw_policy.h
+++ b/mav_planning_common/include/mav_planning_common/yaw_policy.h
@@ -1,0 +1,71 @@
+#ifndef MAV_PLANNING_COMMON_YAW_POLICY_H_
+#define MAV_PLANNING_COMMON_YAW_POLICY_H_
+
+#include <mav_msgs/eigen_mav_msgs.h>
+
+#include "mav_planning_common/physical_constraints.h"
+
+namespace mav_planning {
+
+class YawPolicy {
+ public:
+  enum class PolicyType {
+    kFromPlan = 0,
+    kVelocityVector,
+    kAnticipateVelocityVector,
+    kPointFacing,
+    kConstant
+  };
+
+  YawPolicy()
+      : policy_(PolicyType::kFromPlan), sampling_dt_(-1), yaw_rate_max_(-1) {}
+  YawPolicy(PolicyType policy)
+      : policy_(policy), sampling_dt_(-1), yaw_rate_max_(-1) {}
+
+  void setYawPolicy(PolicyType policy) { policy_ = policy; }
+  PolicyType getYawPolicy() const { return policy_; }
+
+  void setPhysicalConstraints(const PhysicalConstraints& constraints);
+
+  void setSamplingDt(double sampling_dt);
+  double getSamplingDt() { return sampling_dt_; }
+
+  void setYawRateMax(double yaw_rate_max);
+  double getYawRateMax() { return yaw_rate_max_; }
+
+  void deactivateMaxYawRate() { yaw_rate_max_ = -1; }
+
+  void applyPolicyInPlace(mav_msgs::EigenTrajectoryPointVector* path);
+  void applyPolicy(const mav_msgs::EigenTrajectoryPointVector& path_in,
+                   mav_msgs::EigenTrajectoryPointVector* path_out);
+
+  void applyPolicyInPlace(double initial_yaw,
+                          mav_msgs::EigenTrajectoryPointVector* path,
+                          bool initial_yaw_given = true);
+  void applyPolicy(const mav_msgs::EigenTrajectoryPointVector& path_in,
+                   double initial_yaw,
+                   mav_msgs::EigenTrajectoryPointVector* path_out,
+                   bool initial_yaw_given = true);
+
+  void setFacingPoint(const Eigen::Vector3d& point) { facing_point_ = point; }
+  Eigen::Vector3d getFacingPoint() const { return facing_point_; }
+
+  void setConstantYaw(double yaw) { constant_yaw_ = yaw; }
+  double getConstantYaw() const { return constant_yaw_; }
+
+ private:
+  PolicyType policy_;
+  double sampling_dt_;
+  double yaw_rate_max_;
+
+  // Only used for constant yaw policy.
+  double constant_yaw_;
+  // Only used for point-facing policy.
+  Eigen::Vector3d facing_point_;
+
+  double getFeasibleYaw(double last_yaw, double desired_yaw);
+};
+
+}  // namespace mav_planning
+
+#endif  // MAV_PLANNING_COMMON_YAW_POLICY_H_

--- a/mav_planning_common/src/yaw_policy.cpp
+++ b/mav_planning_common/src/yaw_policy.cpp
@@ -26,27 +26,12 @@ void YawPolicy::setYawRateMax(double yaw_rate_max) {
 }
 
 void YawPolicy::applyPolicyInPlace(mav_msgs::EigenTrajectoryPointVector* path) {
-  double initial_yaw = 0.0;
-  bool initial_yaw_given = false;
-  applyPolicyInPlace(initial_yaw, path, initial_yaw_given);
-}
+  if (path->empty()) {
+    return;
+  }
 
-void YawPolicy::applyPolicy(const mav_msgs::EigenTrajectoryPointVector& path_in,
-                            mav_msgs::EigenTrajectoryPointVector* path_out) {
-  double initial_yaw = 0.0;
-  bool initial_yaw_given = false;
-  applyPolicy(path_in, initial_yaw, path_out, initial_yaw_given);
-}
-
-void YawPolicy::applyPolicyInPlace(double initial_yaw,
-                                   mav_msgs::EigenTrajectoryPointVector* path,
-                                   bool initial_yaw_given) {
-  // To check feasibility of next yaw
-  double last_yaw = initial_yaw_given ? initial_yaw : constant_yaw_;
-  // To continue tracking a yaw if it has not been reached yet and no new yaw
-  // has to be tracked.
-  double last_desired_yaw = last_yaw;
-  bool valid_last_yaw = initial_yaw_given;
+  double last_yaw = path->front().getYaw();
+  bool valid_last_yaw = true;
 
   if (policy_ == PolicyType::kFromPlan) {
     // Don't have to do anything! :)
@@ -73,7 +58,6 @@ void YawPolicy::applyPolicyInPlace(double initial_yaw,
         double yaw = getFeasibleYaw(last_yaw, desired_yaw);
         point.setFromYaw(yaw);
         last_yaw = yaw;
-        last_desired_yaw = desired_yaw;
         valid_last_yaw = true;
       } else {
         // Case 2: near-zero velocity.
@@ -90,28 +74,18 @@ void YawPolicy::applyPolicyInPlace(double initial_yaw,
         } else {
           // Case 2b: no non-zero velocity point further on, track last valid
           // one
-          if (!valid_last_yaw) {
-            ROS_ERROR(
-                "No valid velocity found in trajectory and no initial yaw "
-                "given! Setting yaw to 0.");
-            desired_yaw = 0;
-            valid_last_yaw = true;  // Such that error is thrown only once per
-                                    // trajectory, on the rest of trajectory yaw
-                                    // will anyways be 0
-          } else {
-            desired_yaw = last_desired_yaw;
-          }
+          desired_yaw = last_yaw;
         }
         double yaw = getFeasibleYaw(last_yaw, desired_yaw);
         point.setFromYaw(yaw);
         last_yaw = yaw;
-        last_desired_yaw = desired_yaw;
       }
     }
   } else if (policy_ == PolicyType::kAnticipateVelocityVector) {
     // Same as kVelocityVector, but max_yaw_rate is guaranteed by anticipating
     // the future desired yaws.
     valid_last_yaw = false;
+    double initial_yaw = last_yaw;
     for (size_t i = path->size(); i > 0; --i) {
       // Non-const ref that gets modified below.
       mav_msgs::EigenTrajectoryPoint& point = (*path)[i - 1];
@@ -130,7 +104,6 @@ void YawPolicy::applyPolicyInPlace(double initial_yaw,
         double yaw = getFeasibleYaw(last_yaw, desired_yaw);
         point.setFromYaw(yaw);
         last_yaw = yaw;
-        last_desired_yaw = desired_yaw;
         valid_last_yaw = true;
       } else {
         // Case 2: near-zero velocity.
@@ -146,48 +119,24 @@ void YawPolicy::applyPolicyInPlace(double initial_yaw,
         } else {
           // Case 2b: no non-zero velocity point further on, track last valid
           // one
-          if (!valid_last_yaw) {
-            if (initial_yaw_given) {
-              ROS_WARN(
-                  "No valid velocity found in trajectory, setting yaw to "
-                  "initial_yaw: %f",
-                  initial_yaw);
-              desired_yaw = initial_yaw;
-            } else {
-              ROS_ERROR(
-                  "No valid velocity found in trajectory and no initial yaw "
-                  "given! Setting yaw to 0.");
-              desired_yaw = 0;
-            }
-            valid_last_yaw = true;
-          } else {
-            desired_yaw = last_desired_yaw;
-          }
+          desired_yaw = last_yaw;
         }
         double yaw = getFeasibleYaw(last_yaw, desired_yaw);
         point.setFromYaw(yaw);
         last_yaw = yaw;
-        last_desired_yaw = desired_yaw;
       }
     }
 
-    if (initial_yaw_given && path->size() > 0) {
-      const double kYawDifferenceThreshold = 0.01;
-      // Now set initial part of the trajectory so that initial_yaw is achieved.
-      (*path)[0].setFromYaw(initial_yaw);
-      last_yaw = initial_yaw;
-      for (size_t i = 0; i < path->size(); ++i) {
-        // Non-const ref that gets modified below.
-        mav_msgs::EigenTrajectoryPoint& point = (*path)[i];
-        double desired_yaw = point.getYaw();
-        double yaw = getFeasibleYaw(last_yaw, desired_yaw);
-        if (yaw - desired_yaw < kYawDifferenceThreshold) {
-          // Now just follow yaw that was computed before.
-          break;
-        }
-        point.setFromYaw(yaw);
-        last_yaw = yaw;
-      }
+    // Now set initial part of the trajectory so that initial_yaw is achieved.
+    (*path)[0].setFromYaw(initial_yaw);
+    last_yaw = initial_yaw;
+    for (size_t i = 0; i < path->size(); ++i) {
+      // Non-const ref that gets modified below.
+      mav_msgs::EigenTrajectoryPoint& point = (*path)[i];
+      double desired_yaw = point.getYaw();
+      double yaw = getFeasibleYaw(last_yaw, desired_yaw);
+      point.setFromYaw(yaw);
+      last_yaw = yaw;
     }
   } else if (policy_ == PolicyType::kPointFacing) {
     // Try to figure out how to constantly face toward the same point.
@@ -198,7 +147,7 @@ void YawPolicy::applyPolicyInPlace(double initial_yaw,
 
       // Catch the case of both inputs being 0... When we pass directly over
       // the facing point.
-      double desired_yaw = last_desired_yaw;
+      double desired_yaw = last_yaw;
       if (std::abs(facing_direction.x()) > 1e-4 ||
           std::abs(facing_direction.y()) > 1e-4) {
         desired_yaw = atan2(facing_direction.y(), facing_direction.x());
@@ -210,13 +159,10 @@ void YawPolicy::applyPolicyInPlace(double initial_yaw,
       double yaw = getFeasibleYaw(last_yaw, desired_yaw);
       point.setFromYaw(yaw);
       last_yaw = yaw;
-      last_desired_yaw = desired_yaw;
     }
   } else if (policy_ == PolicyType::kConstant) {
     // Just go through the whole path and update the whole thing.
-    if (!initial_yaw_given) {
-      last_yaw = constant_yaw_;
-    }
+    last_yaw = constant_yaw_;
     for (size_t i = 0; i < path->size(); ++i) {
       // Non-const ref that gets modified below.
       mav_msgs::EigenTrajectoryPoint& point = (*path)[i];
@@ -225,16 +171,6 @@ void YawPolicy::applyPolicyInPlace(double initial_yaw,
       last_yaw = yaw;
     }
   }
-}
-
-void YawPolicy::applyPolicy(const mav_msgs::EigenTrajectoryPointVector& path_in,
-                            double initial_yaw,
-                            mav_msgs::EigenTrajectoryPointVector* path_out,
-                            bool initial_yaw_given) {
-  path_out->clear();
-  *path_out = path_in;
-
-  applyPolicyInPlace(initial_yaw, path_out, initial_yaw_given);
 }
 
 double YawPolicy::getFeasibleYaw(double last_yaw, double desired_yaw) {

--- a/mav_planning_common/src/yaw_policy.cpp
+++ b/mav_planning_common/src/yaw_policy.cpp
@@ -1,0 +1,264 @@
+#include <ros/console.h>
+
+#include "mav_planning_common/yaw_policy.h"
+
+namespace mav_planning {
+
+void YawPolicy::setPhysicalConstraints(const PhysicalConstraints& constraints) {
+  sampling_dt_ = constraints.sampling_dt;
+  yaw_rate_max_ = constraints.yaw_rate_max;
+}
+
+void YawPolicy::setSamplingDt(double sampling_dt) {
+  if (sampling_dt <= 0.0) {
+    ROS_ERROR("Sampling dt must be non-zero and positive!");
+    return;
+  }
+  sampling_dt_ = sampling_dt;
+}
+
+void YawPolicy::setYawRateMax(double yaw_rate_max) {
+  if (yaw_rate_max <= 0.0) {
+    ROS_ERROR("Max yaw rate must be positive!");
+    return;
+  }
+  yaw_rate_max_ = yaw_rate_max;
+}
+
+void YawPolicy::applyPolicyInPlace(mav_msgs::EigenTrajectoryPointVector* path) {
+  double initial_yaw = 0.0;
+  bool initial_yaw_given = false;
+  applyPolicyInPlace(initial_yaw, path, initial_yaw_given);
+}
+
+void YawPolicy::applyPolicy(const mav_msgs::EigenTrajectoryPointVector& path_in,
+                            mav_msgs::EigenTrajectoryPointVector* path_out) {
+  double initial_yaw = 0.0;
+  bool initial_yaw_given = false;
+  applyPolicy(path_in, initial_yaw, path_out, initial_yaw_given);
+}
+
+void YawPolicy::applyPolicyInPlace(double initial_yaw,
+                                   mav_msgs::EigenTrajectoryPointVector* path,
+                                   bool initial_yaw_given) {
+  // To check feasibility of next yaw
+  double last_yaw = initial_yaw_given ? initial_yaw : constant_yaw_;
+  // To continue tracking a yaw if it has not been reached yet and no new yaw
+  // has to be tracked.
+  double last_desired_yaw = last_yaw;
+  bool valid_last_yaw = initial_yaw_given;
+
+  if (policy_ == PolicyType::kFromPlan) {
+    // Don't have to do anything! :)
+    return;
+  } else if (policy_ == PolicyType::kVelocityVector) {
+    // Track velocity vector. If current point has near-zero velocity, track
+    // next non-zero velocity. If there is none (end of trajectory), track last
+    // non-zero velocity.
+    const double kMinVelocityNorm = 0.1;
+    for (size_t i = 0; i < path->size(); ++i) {
+      // Non-const ref that gets modified below.
+      mav_msgs::EigenTrajectoryPoint& point = (*path)[i];
+
+      // Case 1: non-zero velocity at current point (ignoring vertical
+      // component).
+      Eigen::Vector3d velocity_xy = point.velocity_W;
+      velocity_xy.z() = 0;
+      if (velocity_xy.norm() > kMinVelocityNorm) {
+        double desired_yaw = atan2(velocity_xy.y(), velocity_xy.x());
+        if (!valid_last_yaw) {
+          // No initial yaw had been chosen yet
+          last_yaw = desired_yaw;
+        }
+        double yaw = getFeasibleYaw(last_yaw, desired_yaw);
+        point.setFromYaw(yaw);
+        last_yaw = yaw;
+        last_desired_yaw = desired_yaw;
+        valid_last_yaw = true;
+      } else {
+        // Case 2: near-zero velocity.
+        double desired_yaw;
+        size_t j = i + 1;
+        while (j < path->size() && velocity_xy.norm() < kMinVelocityNorm) {
+          velocity_xy = (*path)[j].velocity_W;
+          velocity_xy.z() = 0;
+          j++;
+        }
+        if (velocity_xy.norm() > kMinVelocityNorm) {
+          // Case 2a: there is a non-zero velocity point further on
+          desired_yaw = atan2(velocity_xy.y(), velocity_xy.x());
+        } else {
+          // Case 2b: no non-zero velocity point further on, track last valid
+          // one
+          if (!valid_last_yaw) {
+            ROS_ERROR(
+                "No valid velocity found in trajectory and no initial yaw "
+                "given! Setting yaw to 0.");
+            desired_yaw = 0;
+            valid_last_yaw = true;  // Such that error is thrown only once per
+                                    // trajectory, on the rest of trajectory yaw
+                                    // will anyways be 0
+          } else {
+            desired_yaw = last_desired_yaw;
+          }
+        }
+        double yaw = getFeasibleYaw(last_yaw, desired_yaw);
+        point.setFromYaw(yaw);
+        last_yaw = yaw;
+        last_desired_yaw = desired_yaw;
+      }
+    }
+  } else if (policy_ == PolicyType::kAnticipateVelocityVector) {
+    // Same as kVelocityVector, but max_yaw_rate is guaranteed by anticipating
+    // the future desired yaws.
+    valid_last_yaw = false;
+    for (size_t i = path->size(); i > 0; --i) {
+      // Non-const ref that gets modified below.
+      mav_msgs::EigenTrajectoryPoint& point = (*path)[i - 1];
+      const double kMinVelocityNorm = 0.1;
+
+      // Case 1: non-zero velocity at current point (ignoring vertical
+      // component).
+      Eigen::Vector3d velocity_xy = point.velocity_W;
+      velocity_xy.z() = 0;
+      if (velocity_xy.norm() > kMinVelocityNorm) {
+        double desired_yaw = atan2(velocity_xy.y(), velocity_xy.x());
+        if (!valid_last_yaw) {
+          // No initial yaw had been chosen yet
+          last_yaw = desired_yaw;
+        }
+        double yaw = getFeasibleYaw(last_yaw, desired_yaw);
+        point.setFromYaw(yaw);
+        last_yaw = yaw;
+        last_desired_yaw = desired_yaw;
+        valid_last_yaw = true;
+      } else {
+        // Case 2: near-zero velocity.
+        double desired_yaw;
+        for (size_t j = i; j > 0 && velocity_xy.norm() < kMinVelocityNorm;
+             --j) {
+          velocity_xy = (*path)[j - 1].velocity_W;
+          velocity_xy.z() = 0;
+        }
+        if (velocity_xy.norm() > kMinVelocityNorm) {
+          // Case 2a: there is a non-zero velocity point further on
+          desired_yaw = atan2(velocity_xy.y(), velocity_xy.x());
+        } else {
+          // Case 2b: no non-zero velocity point further on, track last valid
+          // one
+          if (!valid_last_yaw) {
+            if (initial_yaw_given) {
+              ROS_WARN(
+                  "No valid velocity found in trajectory, setting yaw to "
+                  "initial_yaw: %f",
+                  initial_yaw);
+              desired_yaw = initial_yaw;
+            } else {
+              ROS_ERROR(
+                  "No valid velocity found in trajectory and no initial yaw "
+                  "given! Setting yaw to 0.");
+              desired_yaw = 0;
+            }
+            valid_last_yaw = true;
+          } else {
+            desired_yaw = last_desired_yaw;
+          }
+        }
+        double yaw = getFeasibleYaw(last_yaw, desired_yaw);
+        point.setFromYaw(yaw);
+        last_yaw = yaw;
+        last_desired_yaw = desired_yaw;
+      }
+    }
+
+    if (initial_yaw_given && path->size() > 0) {
+      const double kYawDifferenceThreshold = 0.01;
+      // Now set initial part of the trajectory so that initial_yaw is achieved.
+      (*path)[0].setFromYaw(initial_yaw);
+      last_yaw = initial_yaw;
+      for (size_t i = 0; i < path->size(); ++i) {
+        // Non-const ref that gets modified below.
+        mav_msgs::EigenTrajectoryPoint& point = (*path)[i];
+        double desired_yaw = point.getYaw();
+        double yaw = getFeasibleYaw(last_yaw, desired_yaw);
+        if (yaw - desired_yaw < kYawDifferenceThreshold) {
+          // Now just follow yaw that was computed before.
+          break;
+        }
+        point.setFromYaw(yaw);
+        last_yaw = yaw;
+      }
+    }
+  } else if (policy_ == PolicyType::kPointFacing) {
+    // Try to figure out how to constantly face toward the same point.
+    for (size_t i = 0; i < path->size(); ++i) {
+      // Non-const ref that gets modified below.
+      mav_msgs::EigenTrajectoryPoint& point = (*path)[i];
+      Eigen::Vector3d facing_direction = facing_point_ - point.position_W;
+
+      // Catch the case of both inputs being 0... When we pass directly over
+      // the facing point.
+      double desired_yaw = last_desired_yaw;
+      if (std::abs(facing_direction.x()) > 1e-4 ||
+          std::abs(facing_direction.y()) > 1e-4) {
+        desired_yaw = atan2(facing_direction.y(), facing_direction.x());
+      }
+      if (!valid_last_yaw) {
+        last_yaw = desired_yaw;
+        valid_last_yaw = true;
+      }
+      double yaw = getFeasibleYaw(last_yaw, desired_yaw);
+      point.setFromYaw(yaw);
+      last_yaw = yaw;
+      last_desired_yaw = desired_yaw;
+    }
+  } else if (policy_ == PolicyType::kConstant) {
+    // Just go through the whole path and update the whole thing.
+    if (!initial_yaw_given) {
+      last_yaw = constant_yaw_;
+    }
+    for (size_t i = 0; i < path->size(); ++i) {
+      // Non-const ref that gets modified below.
+      mav_msgs::EigenTrajectoryPoint& point = (*path)[i];
+      double yaw = getFeasibleYaw(last_yaw, constant_yaw_);
+      point.setFromYaw(yaw);
+      last_yaw = yaw;
+    }
+  }
+}
+
+void YawPolicy::applyPolicy(const mav_msgs::EigenTrajectoryPointVector& path_in,
+                            double initial_yaw,
+                            mav_msgs::EigenTrajectoryPointVector* path_out,
+                            bool initial_yaw_given) {
+  path_out->clear();
+  *path_out = path_in;
+
+  applyPolicyInPlace(initial_yaw, path_out, initial_yaw_given);
+}
+
+double YawPolicy::getFeasibleYaw(double last_yaw, double desired_yaw) {
+  if (yaw_rate_max_ < 0) {  // yaw_rate_max_ deactivated
+    return desired_yaw;
+  }
+  if (sampling_dt_ < 0) {
+    std::cerr << "sampling_dt_ has to be set!\n";
+    return 0;
+  }
+  // Compute delta yaw (between -PI and PI)
+  double yaw_mod = fmod(desired_yaw - last_yaw, 2 * M_PI);
+  if (yaw_mod < -M_PI) {
+    yaw_mod += 2 * M_PI;
+  } else if (yaw_mod > M_PI) {
+    yaw_mod -= 2 * M_PI;
+  }
+
+  // Check if yaw rate is feasible
+  if (std::abs(yaw_mod) > yaw_rate_max_ * sampling_dt_) {
+    double yaw_direction = yaw_mod > 0.0 ? 1.0 : -1.0;
+    return last_yaw + yaw_direction * yaw_rate_max_ * sampling_dt_;
+  }
+  return desired_yaw;
+}
+
+}  // namespace mav_planning

--- a/mav_planning_rviz/include/mav_planning_rviz/planning_panel.h
+++ b/mav_planning_rviz/include/mav_planning_rviz/planning_panel.h
@@ -50,6 +50,8 @@ class PlanningPanel : public rviz::Panel {
                          mav_msgs::EigenTrajectoryPoint& pose);
   void callPlannerService();
   void callPublishPath();
+  void publishWaypoint();
+  void publishToController();
 
  protected:
   // Set up the layout, only called by the constructor.
@@ -59,6 +61,8 @@ class PlanningPanel : public rviz::Panel {
 
   // ROS Stuff:
   ros::NodeHandle nh_;
+  ros::Publisher waypoint_pub_;
+  ros::Publisher controller_pub_;
 
   // QT stuff:
   QLineEdit* namespace_editor_;
@@ -67,6 +71,8 @@ class PlanningPanel : public rviz::Panel {
   PoseWidget* goal_pose_widget_;
   QPushButton* planner_service_button_;
   QPushButton* publish_path_button_;
+  QPushButton* waypoint_button_;
+  QPushButton* controller_button_;
 
   // Keep track of all the pose <-> button widgets as they're related:
   std::map<std::string, PoseWidget*> pose_widget_map_;

--- a/mav_planning_rviz/src/planning_panel.cpp
+++ b/mav_planning_rviz/src/planning_panel.cpp
@@ -40,8 +40,6 @@ void PlanningPanel::onInitialize() {
     kv.second->getPose(&pose);
     interactive_markers_.enableMarker(kv.first, pose);
   }
-
-  ROS_INFO("Initializing.");
 }
 
 void PlanningPanel::createLayout() {
@@ -124,9 +122,9 @@ void PlanningPanel::updateNamespace() {
 
 // Set the topic name we are publishing to.
 void PlanningPanel::setNamespace(const QString& new_namespace) {
-  ROS_INFO_STREAM("Setting namespace from: " << namespace_.toStdString()
-                                             << " to "
-                                             << new_namespace.toStdString());
+  ROS_DEBUG_STREAM("Setting namespace from: " << namespace_.toStdString()
+                                              << " to "
+                                              << new_namespace.toStdString());
   // Only take action if the name has changed.
   if (new_namespace != namespace_) {
     namespace_ = new_namespace;
@@ -267,7 +265,7 @@ void PlanningPanel::callPlannerService() {
                                                      &req.request.goal_pose);
 
     try {
-      ROS_INFO_STREAM("Service name: " << service_name);
+      ROS_DEBUG_STREAM("Service name: " << service_name);
       if (!ros::service::call(service_name, req)) {
         ROS_WARN_STREAM("Couldn't call service: " << service_name);
       }
@@ -299,9 +297,9 @@ void PlanningPanel::publishWaypoint() {
   pose.header.frame_id = vis_manager_->getFixedFrame().toStdString();
   mav_msgs::msgPoseStampedFromEigenTrajectoryPoint(goal_point, &pose);
 
-  ROS_INFO_STREAM("Publishing waypoint on "
-                  << waypoint_pub_.getTopic()
-                  << " subscribers: " << waypoint_pub_.getNumSubscribers());
+  ROS_DEBUG_STREAM("Publishing waypoint on "
+                   << waypoint_pub_.getTopic()
+                   << " subscribers: " << waypoint_pub_.getNumSubscribers());
 
   waypoint_pub_.publish(pose);
 }
@@ -314,9 +312,9 @@ void PlanningPanel::publishToController() {
   pose.header.frame_id = vis_manager_->getFixedFrame().toStdString();
   mav_msgs::msgPoseStampedFromEigenTrajectoryPoint(goal_point, &pose);
 
-  ROS_INFO_STREAM("Publishing controller goal on "
-                  << controller_pub_.getTopic()
-                  << " subscribers: " << controller_pub_.getNumSubscribers());
+  ROS_DEBUG_STREAM("Publishing controller goal on "
+                   << controller_pub_.getTopic()
+                   << " subscribers: " << controller_pub_.getNumSubscribers());
 
   controller_pub_.publish(pose);
 }

--- a/mav_planning_rviz/src/planning_panel.cpp
+++ b/mav_planning_rviz/src/planning_panel.cpp
@@ -12,6 +12,7 @@
 
 #include <geometry_msgs/Twist.h>
 #include <mav_planning_msgs/PlannerService.h>
+#include <ros/names.h>
 #include <rviz/visualization_manager.h>
 #include <std_srvs/Empty.h>
 
@@ -39,6 +40,8 @@ void PlanningPanel::onInitialize() {
     kv.second->getPose(&pose);
     interactive_markers_.enableMarker(kv.first, pose);
   }
+
+  ROS_INFO("Initializing.");
 }
 
 void PlanningPanel::createLayout() {
@@ -87,11 +90,18 @@ void PlanningPanel::createLayout() {
   service_layout->addWidget(planner_service_button_);
   service_layout->addWidget(publish_path_button_);
 
+  QHBoxLayout* local_planner_layout = new QHBoxLayout;
+  waypoint_button_ = new QPushButton("Send Waypoint");
+  controller_button_ = new QPushButton("Send To Controller");
+  local_planner_layout->addWidget(waypoint_button_);
+  local_planner_layout->addWidget(controller_button_);
+
   // First the names, then the start/goal, then service buttons.
   QVBoxLayout* layout = new QVBoxLayout;
   layout->addLayout(topic_layout);
   layout->addLayout(start_goal_layout);
   layout->addLayout(service_layout);
+  layout->addLayout(local_planner_layout);
   setLayout(layout);
 
   // Hook up connections.
@@ -103,6 +113,9 @@ void PlanningPanel::createLayout() {
           SLOT(callPlannerService()));
   connect(publish_path_button_, SIGNAL(released()), this,
           SLOT(callPublishPath()));
+  connect(waypoint_button_, SIGNAL(released()), this, SLOT(publishWaypoint()));
+  connect(controller_button_, SIGNAL(released()), this,
+          SLOT(publishToController()));
 }
 
 void PlanningPanel::updateNamespace() {
@@ -111,10 +124,21 @@ void PlanningPanel::updateNamespace() {
 
 // Set the topic name we are publishing to.
 void PlanningPanel::setNamespace(const QString& new_namespace) {
+  ROS_INFO_STREAM("Setting namespace from: " << namespace_.toStdString()
+                                             << " to "
+                                             << new_namespace.toStdString());
   // Only take action if the name has changed.
   if (new_namespace != namespace_) {
     namespace_ = new_namespace;
     Q_EMIT configChanged();
+
+    std::string error;
+    if (ros::names::validate(namespace_.toStdString(), error)) {
+      waypoint_pub_ = nh_.advertise<geometry_msgs::PoseStamped>(
+          namespace_.toStdString() + "/waypoint", 1, false);
+      controller_pub_ = nh_.advertise<geometry_msgs::PoseStamped>(
+          namespace_.toStdString() + "/command/pose", 1, false);
+    }
   }
 }
 
@@ -197,8 +221,10 @@ void PlanningPanel::save(rviz::Config config) const {
 void PlanningPanel::load(const rviz::Config& config) {
   rviz::Panel::load(config);
   QString topic;
-  if (config.mapGetString("namespace", &namespace_)) {
-    namespace_editor_->setText(namespace_);
+  QString ns;
+  if (config.mapGetString("namespace", &ns)) {
+    namespace_editor_->setText(ns);
+    updateNamespace();
   }
   if (config.mapGetString("planner_name", &planner_name_)) {
     planner_name_editor_->setText(planner_name_);
@@ -265,7 +291,37 @@ void PlanningPanel::callPublishPath() {
   }
 }
 
-}  // end namespace mav_planning_rviz
+void PlanningPanel::publishWaypoint() {
+  mav_msgs::EigenTrajectoryPoint goal_point;
+  goal_pose_widget_->getPose(&goal_point);
+
+  geometry_msgs::PoseStamped pose;
+  pose.header.frame_id = vis_manager_->getFixedFrame().toStdString();
+  mav_msgs::msgPoseStampedFromEigenTrajectoryPoint(goal_point, &pose);
+
+  ROS_INFO_STREAM("Publishing waypoint on "
+                  << waypoint_pub_.getTopic()
+                  << " subscribers: " << waypoint_pub_.getNumSubscribers());
+
+  waypoint_pub_.publish(pose);
+}
+
+void PlanningPanel::publishToController() {
+  mav_msgs::EigenTrajectoryPoint goal_point;
+  goal_pose_widget_->getPose(&goal_point);
+
+  geometry_msgs::PoseStamped pose;
+  pose.header.frame_id = vis_manager_->getFixedFrame().toStdString();
+  mav_msgs::msgPoseStampedFromEigenTrajectoryPoint(goal_point, &pose);
+
+  ROS_INFO_STREAM("Publishing controller goal on "
+                  << controller_pub_.getTopic()
+                  << " subscribers: " << controller_pub_.getNumSubscribers());
+
+  controller_pub_.publish(pose);
+}
+
+}  // namespace mav_planning_rviz
 
 // Tell pluginlib about this class.  Every class which should be
 // loadable by pluginlib::ClassLoader must have these two lines

--- a/mav_voxblox_planning/package.xml
+++ b/mav_voxblox_planning/package.xml
@@ -9,10 +9,12 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>loco_planner</run_depend>
+  <run_depend>mav_local_planner</run_depend>
   <run_depend>mav_path_smoothing</run_depend>
   <run_depend>mav_planning_benchmark</run_depend>
   <run_depend>mav_planning_common</run_depend>
   <run_depend>mav_planning_rviz</run_depend>
+  <run_depend>voxblox_loco_planner</run_depend>
   <run_depend>voxblox_rrt_planner</run_depend>
   <run_depend>voxblox_skeleton</run_depend>
   <run_depend>voxblox_skeleton_planner</run_depend>

--- a/voxblox_loco_planner/CMakeLists.txt
+++ b/voxblox_loco_planner/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(voxblox_loco_planner)
+
+find_package(catkin_simple REQUIRED)
+catkin_simple(ALL_DEPS_REQUIRED)
+
+add_definitions(-std=c++11)
+
+#############
+# LIBRARIES #
+#############
+cs_add_library(${PROJECT_NAME}
+  src/voxblox_loco_planner.cpp
+)
+
+############
+# BINARIES #
+############
+#cs_add_executable(global_planning_benchmark_node
+#  src/global_planning_benchmark_node.cpp
+#)
+#target_link_libraries(global_planning_benchmark_node ${PROJECT_NAME})
+
+##########
+# EXPORT #
+##########
+cs_install()
+cs_export()

--- a/voxblox_loco_planner/include/voxblox_loco_planner/voxblox_loco_planner.h
+++ b/voxblox_loco_planner/include/voxblox_loco_planner/voxblox_loco_planner.h
@@ -24,6 +24,23 @@ class VoxbloxLocoPlanner {
   // MUST be called to associate the map with the planner.
   void setEsdfMap(const std::shared_ptr<voxblox::EsdfMap>& esdf_map);
 
+  bool getTrajectoryTowardGoal(
+      const mav_msgs::EigenTrajectoryPoint& start,
+      const mav_msgs::EigenTrajectoryPoint& goal,
+      mav_trajectory_generation::Trajectory* trajectory);
+
+  bool getTrajectoryTowardGoalFromInitialTrajectory(
+      double start_time,
+      const mav_trajectory_generation::Trajectory& trajectory_in,
+      const mav_msgs::EigenTrajectoryPoint& goal,
+      mav_trajectory_generation::Trajectory* trajectory);
+
+  bool getTrajectoryBetweenWaypoints(
+      const mav_msgs::EigenTrajectoryPoint& start,
+      const mav_msgs::EigenTrajectoryPoint& goal,
+      mav_trajectory_generation::Trajectory* trajectory);
+
+ private:
   // Callbacks to bind to loco.
   double getMapDistance(const Eigen::Vector3d& position) const;
   double getMapDistanceAndGradient(const Eigen::Vector3d& position,
@@ -36,7 +53,15 @@ class VoxbloxLocoPlanner {
       const mav_msgs::EigenTrajectoryPointVector& path) const;
   bool isPathFeasible(const mav_msgs::EigenTrajectoryPointVector& path) const;
 
- private:
+  // Intermediate goal-finding.
+  bool findIntermediateGoal(const mav_msgs::EigenTrajectoryPoint& start,
+                            const mav_msgs::EigenTrajectoryPoint& goal,
+                            double step_size,
+                            mav_msgs::EigenTrajectoryPoint* goal_out) const;
+
+  bool getNearestFreeSpaceToPoint(const Eigen::Vector3d& pos, double step_size,
+                                  Eigen::Vector3d* new_pos) const;
+
   ros::NodeHandle nh_;
   ros::NodeHandle nh_private_;
 
@@ -47,6 +72,12 @@ class VoxbloxLocoPlanner {
   bool verbose_;
   bool visualize_;
   std::string frame_id_;
+
+  // Loco settings.
+  int num_segments_;
+  int num_random_restarts_;
+  double random_restart_magnitude_;
+  double planning_horizon_m_;
 
   // Planner.
   loco_planner::Loco<kN> loco_;

--- a/voxblox_loco_planner/include/voxblox_loco_planner/voxblox_loco_planner.h
+++ b/voxblox_loco_planner/include/voxblox_loco_planner/voxblox_loco_planner.h
@@ -54,13 +54,14 @@ class VoxbloxLocoPlanner {
   bool isPathFeasible(const mav_msgs::EigenTrajectoryPointVector& path) const;
 
   // Intermediate goal-finding.
-  bool findIntermediateGoal(const mav_msgs::EigenTrajectoryPoint& start,
-                            const mav_msgs::EigenTrajectoryPoint& goal,
-                            double step_size,
-                            mav_msgs::EigenTrajectoryPoint* goal_out) const;
+  bool findIntermediateGoal(
+    const mav_msgs::EigenTrajectoryPoint& start,
+    const mav_msgs::EigenTrajectoryPoint& goal, double step_size,
+    mav_msgs::EigenTrajectoryPoint* goal_out) const;
 
-  bool getNearestFreeSpaceToPoint(const Eigen::Vector3d& pos, double step_size,
-                                  Eigen::Vector3d* new_pos) const;
+bool getNearestFreeSpaceToPoint(
+    const Eigen::Vector3d& pos, double step_size,
+    Eigen::Vector3d* new_pos) const;
 
   ros::NodeHandle nh_;
   ros::NodeHandle nh_private_;

--- a/voxblox_loco_planner/include/voxblox_loco_planner/voxblox_loco_planner.h
+++ b/voxblox_loco_planner/include/voxblox_loco_planner/voxblox_loco_planner.h
@@ -1,0 +1,60 @@
+#ifndef VOXBLOX_LOCO_PLANNER_VOXBLOX_LOCO_PLANNER_H_
+#define VOXBLOX_LOCO_PLANNER_VOXBLOX_LOCO_PLANNER_H_
+
+#include <loco_planner/loco.h>
+#include <mav_planning_common/color_utils.h>
+#include <mav_planning_common/path_visualization.h>
+#include <mav_planning_common/physical_constraints.h>
+#include <mav_planning_common/utils.h>
+#include <mav_trajectory_generation/timing.h>
+#include <mav_visualization/helpers.h>
+#include <voxblox/core/common.h>
+#include <voxblox/core/esdf_map.h>
+#include <voxblox/utils/planning_utils.h>
+
+namespace mav_planning {
+
+class VoxbloxLocoPlanner {
+ public:
+  static constexpr int kN = 10;
+
+  VoxbloxLocoPlanner(const ros::NodeHandle& nh,
+                     const ros::NodeHandle& nh_private);
+
+  // MUST be called to associate the map with the planner.
+  void setEsdfMap(const std::shared_ptr<voxblox::EsdfMap>& esdf_map);
+
+  // Callbacks to bind to loco.
+  double getMapDistance(const Eigen::Vector3d& position) const;
+  double getMapDistanceAndGradient(const Eigen::Vector3d& position,
+                                   Eigen::Vector3d* gradient) const;
+  double getMapDistanceAndGradientVector(const Eigen::VectorXd& position,
+                                         Eigen::VectorXd* gradient) const;
+
+  // Evaluate what we've got here.
+  bool isPathCollisionFree(
+      const mav_msgs::EigenTrajectoryPointVector& path) const;
+  bool isPathFeasible(const mav_msgs::EigenTrajectoryPointVector& path) const;
+
+ private:
+  ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
+
+  // Settings for physical constriants.
+  PhysicalConstraints constraints_;
+
+  // General settings.
+  bool verbose_;
+  bool visualize_;
+  std::string frame_id_;
+
+  // Planner.
+  loco_planner::Loco<kN> loco_;
+
+  // Map.
+  std::shared_ptr<voxblox::EsdfMap> esdf_map_;
+};
+
+}  // namespace mav_planning
+
+#endif  // VOXBLOX_LOCO_PLANNER_VOXBLOX_LOCO_PLANNER_H_

--- a/voxblox_loco_planner/package.xml
+++ b/voxblox_loco_planner/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>voxblox_loco_planner</name>
+  <version>0.0.0</version>
+  <description>
+    Local planning using LOCO and a voxblox map.
+  </description>
+
+  <maintainer email="helen.oleynikova@mavt.ethz.ch">Helen Oleynikova</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>catkin_simple</buildtool_depend>
+
+  <depend>loco_planner</depend>
+  <depend>mav_msgs</depend>
+  <depend>mav_planning_common</depend>
+  <depend>mav_trajectory_generation_ros</depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>tf</depend>
+  <depend>visualization_msgs</depend>
+  <depend>voxblox_ros</depend>
+</package>

--- a/voxblox_loco_planner/src/voxblox_loco_planner.cpp
+++ b/voxblox_loco_planner/src/voxblox_loco_planner.cpp
@@ -22,6 +22,8 @@ VoxbloxLocoPlanner::VoxbloxLocoPlanner(const ros::NodeHandle& nh,
   nh_private_.param("verbose", verbose_, verbose_);
   nh_private_.param("visualize", visualize_, visualize_);
   nh_private_.param("frame_id", frame_id_, frame_id_);
+  nh_private_.param("planning_horizon_m", planning_horizon_m_,
+                    planning_horizon_m_);
 
   loco_.setRobotRadius(constraints_.robot_radius);
 

--- a/voxblox_loco_planner/src/voxblox_loco_planner.cpp
+++ b/voxblox_loco_planner/src/voxblox_loco_planner.cpp
@@ -107,6 +107,10 @@ bool VoxbloxLocoPlanner::getTrajectoryBetweenWaypoints(
     mav_trajectory_generation::Trajectory* trajectory) {
   CHECK(esdf_map_);
 
+  ROS_INFO_STREAM("[Voxblox Loco Planner] Start: "
+                  << start.position_W.transpose()
+                  << " goal: " << goal.position_W.transpose());
+
   double total_time = mav_trajectory_generation::computeTimeVelocityRamp(
       start.position_W, goal.position_W, constraints_.v_max,
       constraints_.a_max);
@@ -127,8 +131,8 @@ bool VoxbloxLocoPlanner::getTrajectoryBetweenWaypoints(
     loco_.getTrajectory(trajectory);
     mav_trajectory_generation::sampleWholeTrajectory(
         *trajectory, kCollisionSamplingDt, &path);
-    bool success = isPathCollisionFree(path);
-
+    success = isPathCollisionFree(path);
+    ROS_INFO("Path length? %zu Success? %d", path.size(), success);
     if (success) {
       // Awesome, collision-free path.
       break;

--- a/voxblox_loco_planner/src/voxblox_loco_planner.cpp
+++ b/voxblox_loco_planner/src/voxblox_loco_planner.cpp
@@ -153,8 +153,21 @@ bool VoxbloxLocoPlanner::getTrajectoryBetweenWaypoints(
 
   if (success) {
     // Retime the trajectory!
+    double a_max, v_max;
+    trajectory->computeMaxVelocityAndAcceleration(&v_max, &a_max);
+    Eigen::VectorXd vel = trajectory->evaluate(0.0, 1);
+    ROS_INFO_STREAM("[Time Scale] Time before: "
+                    << total_time << " a_max: " << a_max << " v_max: " << v_max
+                    << " start vel: " << vel.transpose());
+
     trajectory->scaleSegmentTimesToMeetConstraints(constraints_.v_max,
                                                    constraints_.a_max);
+    trajectory->computeMaxVelocityAndAcceleration(&v_max, &a_max);
+    vel = trajectory->evaluate(0.0, 1);
+    ROS_INFO_STREAM("[Time Scale] Time after: "
+                    << trajectory->getMaxTime() << " a_max: " << a_max
+                    << " v_max: " << v_max
+                    << " start vel: " << vel.transpose());
   }
 
   if (verbose_) {

--- a/voxblox_loco_planner/src/voxblox_loco_planner.cpp
+++ b/voxblox_loco_planner/src/voxblox_loco_planner.cpp
@@ -152,22 +152,7 @@ bool VoxbloxLocoPlanner::getTrajectoryBetweenWaypoints(
   }
 
   if (success) {
-    // Retime the trajectory!
-    double a_max, v_max;
-    trajectory->computeMaxVelocityAndAcceleration(&v_max, &a_max);
-    Eigen::VectorXd vel = trajectory->evaluate(0.0, 1);
-    ROS_INFO_STREAM("[Time Scale] Time before: "
-                    << total_time << " a_max: " << a_max << " v_max: " << v_max
-                    << " start vel: " << vel.transpose());
-
-    trajectory->scaleSegmentTimesToMeetConstraints(constraints_.v_max,
-                                                   constraints_.a_max);
-    trajectory->computeMaxVelocityAndAcceleration(&v_max, &a_max);
-    vel = trajectory->evaluate(0.0, 1);
-    ROS_INFO_STREAM("[Time Scale] Time after: "
-                    << trajectory->getMaxTime() << " a_max: " << a_max
-                    << " v_max: " << v_max
-                    << " start vel: " << vel.transpose());
+    // TODO(helenol): Retime the trajectory!
   }
 
   if (verbose_) {

--- a/voxblox_loco_planner/src/voxblox_loco_planner.cpp
+++ b/voxblox_loco_planner/src/voxblox_loco_planner.cpp
@@ -109,13 +109,15 @@ bool VoxbloxLocoPlanner::getTrajectoryBetweenWaypoints(
     mav_trajectory_generation::Trajectory* trajectory) {
   CHECK(esdf_map_);
 
-  ROS_INFO_STREAM("[Voxblox Loco Planner] Start: "
+  ROS_DEBUG_STREAM("[Voxblox Loco Planner] Start: "
                   << start.position_W.transpose()
                   << " goal: " << goal.position_W.transpose());
 
-  double total_time = mav_trajectory_generation::computeTimeVelocityRamp(
-      start.position_W, goal.position_W, constraints_.v_max,
-      constraints_.a_max);
+  constexpr double kTotalTimeScale = 1.2;
+  double total_time =
+      kTotalTimeScale * mav_trajectory_generation::computeTimeVelocityRamp(
+                            start.position_W, goal.position_W,
+                            constraints_.v_max, constraints_.a_max);
 
   // Check that start and goal aren't basically the same thing...
   constexpr double kMinTime = 0.01;

--- a/voxblox_loco_planner/src/voxblox_loco_planner.cpp
+++ b/voxblox_loco_planner/src/voxblox_loco_planner.cpp
@@ -1,0 +1,92 @@
+#include "voxblox_loco_planner/voxblox_loco_planner.h"
+
+namespace mav_planning {
+
+VoxbloxLocoPlanner::VoxbloxLocoPlanner(const ros::NodeHandle& nh,
+                                       const ros::NodeHandle& nh_private)
+    : nh_(nh),
+      nh_private_(nh_private),
+      verbose_(false),
+      visualize_(true),
+      frame_id_("odom"),
+      loco_(3) {
+  constraints_.setParametersFromRos(nh_private_);
+
+  nh_private_.param("verbose", verbose_, verbose_);
+  nh_private_.param("visualize", visualize_, visualize_);
+  nh_private_.param("frame_id", frame_id_, frame_id_);
+
+  loco_.setRobotRadius(constraints_.robot_radius);
+}
+
+void VoxbloxLocoPlanner::setEsdfMap(
+    const std::shared_ptr<voxblox::EsdfMap>& esdf_map) {
+  CHECK(esdf_map);
+  esdf_map_ = esdf_map;
+
+  loco_.setDistanceAndGradientFunction(
+      std::bind(&VoxbloxLocoPlanner::getMapDistanceAndGradientVector, this,
+                std::placeholders::_1, std::placeholders::_2));
+  loco_.setMapResolution(esdf_map->voxel_size());
+}
+
+double VoxbloxLocoPlanner::getMapDistance(
+    const Eigen::Vector3d& position) const {
+  double distance = 0.0;
+  const bool kInterpolate = false;
+  if (!esdf_map_->getDistanceAtPosition(position, kInterpolate, &distance)) {
+    return 0.0;
+  }
+  return distance;
+}
+
+double VoxbloxLocoPlanner::getMapDistanceAndGradientVector(
+    const Eigen::VectorXd& position, Eigen::VectorXd* gradient) const {
+  CHECK_EQ(position.size(), 3);
+  if (gradient == nullptr) {
+    return getMapDistanceAndGradient(position, nullptr);
+  }
+  Eigen::Vector3d gradient_3d;
+  double distance = getMapDistanceAndGradient(position, &gradient_3d);
+  *gradient = gradient_3d;
+  return distance;
+}
+
+double VoxbloxLocoPlanner::getMapDistanceAndGradient(
+    const Eigen::Vector3d& position, Eigen::Vector3d* gradient) const {
+  double distance = 0.0;
+  const bool kInterpolate = false;
+  if (!esdf_map_->getDistanceAndGradientAtPosition(position, kInterpolate,
+                                                   &distance, gradient)) {
+    return 0.0;
+  }
+  return distance;
+}
+
+// Evaluate what we've got here.
+bool VoxbloxLocoPlanner::isPathCollisionFree(
+    const mav_msgs::EigenTrajectoryPointVector& path) const {
+  for (const mav_msgs::EigenTrajectoryPoint& point : path) {
+    if (getMapDistance(point.position_W) < constraints_.robot_radius) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool VoxbloxLocoPlanner::isPathFeasible(
+    const mav_msgs::EigenTrajectoryPointVector& path) const {
+  // This is easier to check in the trajectory but then we are limited in how
+  // we do the smoothing.
+  for (const mav_msgs::EigenTrajectoryPoint& point : path) {
+    if (point.acceleration_W.norm() > constraints_.a_max + 1e-2) {
+      return false;
+    }
+    if (point.velocity_W.norm() > constraints_.v_max + 1e-2) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace mav_planning

--- a/voxblox_loco_planner/src/voxblox_loco_planner.cpp
+++ b/voxblox_loco_planner/src/voxblox_loco_planner.cpp
@@ -1,3 +1,6 @@
+#include <mav_trajectory_generation/trajectory_sampling.h>
+#include <mav_trajectory_generation/vertex.h>
+
 #include "voxblox_loco_planner/voxblox_loco_planner.h"
 
 namespace mav_planning {
@@ -9,6 +12,10 @@ VoxbloxLocoPlanner::VoxbloxLocoPlanner(const ros::NodeHandle& nh,
       verbose_(false),
       visualize_(true),
       frame_id_("odom"),
+      num_segments_(3),
+      num_random_restarts_(5),
+      random_restart_magnitude_(0.5),
+      planning_horizon_m_(4.0),
       loco_(3) {
   constraints_.setParametersFromRos(nh_private_);
 
@@ -17,6 +24,11 @@ VoxbloxLocoPlanner::VoxbloxLocoPlanner(const ros::NodeHandle& nh,
   nh_private_.param("frame_id", frame_id_, frame_id_);
 
   loco_.setRobotRadius(constraints_.robot_radius);
+
+  double loco_epsilon_inflation = 0.5;
+  nh_private_.param("loco_epsilon_inflation", loco_epsilon_inflation,
+                    loco_epsilon_inflation);
+  loco_.setEpsilon(constraints_.robot_radius + loco_epsilon_inflation);
 }
 
 void VoxbloxLocoPlanner::setEsdfMap(
@@ -87,6 +99,167 @@ bool VoxbloxLocoPlanner::isPathFeasible(
     }
   }
   return true;
+}
+
+bool VoxbloxLocoPlanner::getTrajectoryBetweenWaypoints(
+    const mav_msgs::EigenTrajectoryPoint& start,
+    const mav_msgs::EigenTrajectoryPoint& goal,
+    mav_trajectory_generation::Trajectory* trajectory) {
+  CHECK(esdf_map_);
+
+  double total_time = mav_trajectory_generation::computeTimeVelocityRamp(
+      start.position_W, goal.position_W, constraints_.v_max,
+      constraints_.a_max);
+
+  // If we're doing hotstarts, need to save the previous d_p.
+  loco_.setupFromTrajectoryPoints(start, goal, num_segments_, total_time);
+  Eigen::VectorXd x0, x;
+  loco_.getParameterVector(&x0);
+  x = x0;
+  loco_.solveProblem();
+
+  // Check if this path is collision-free.
+  constexpr double kCollisionSamplingDt = 0.1;
+  mav_msgs::EigenTrajectoryPoint::Vector path;
+  bool success = false;
+  int i = 0;
+  for (i = 0; i < num_random_restarts_; i++) {
+    loco_.getTrajectory(trajectory);
+    mav_trajectory_generation::sampleWholeTrajectory(
+        *trajectory, kCollisionSamplingDt, &path);
+    bool success = isPathCollisionFree(path);
+
+    if (success) {
+      // Awesome, collision-free path.
+      break;
+    }
+
+    // Otherwise let's do some random restarts.
+    x = x0 + random_restart_magnitude_ * Eigen::VectorXd::Random(x.size());
+    loco_.setParameterVector(x);
+    loco_.solveProblem();
+  }
+
+  if (verbose_) {
+    ROS_INFO("[Voxblox Loco Planner] Found solution (%d) after %d restarts.",
+             success, i);
+  }
+  return success;
+}
+
+bool VoxbloxLocoPlanner::getTrajectoryTowardGoal(
+    const mav_msgs::EigenTrajectoryPoint& start,
+    const mav_msgs::EigenTrajectoryPoint& goal,
+    mav_trajectory_generation::Trajectory* trajectory) {
+  CHECK_NOTNULL(trajectory);
+  trajectory->clear();
+  mav_msgs::EigenTrajectoryPoint start_point = start;
+  mav_msgs::EigenTrajectoryPoint goal_point = goal;
+
+  // Check if we're already at the goal!
+  constexpr double kGoalReachedRange = 0.01;
+  if ((goal_point.position_W - start_point.position_W).norm() <
+      kGoalReachedRange) {
+    if (verbose_) {
+      ROS_INFO("[Voxblox Loco Planner] Goal already reached!");
+    }
+    return true;
+  }
+
+  Eigen::Vector3d distance_to_waypoint =
+      goal_point.position_W - start_point.position_W;
+  double planning_distance =
+      (goal_point.position_W - start_point.position_W).norm();
+  Eigen::Vector3d direction_to_waypoint = distance_to_waypoint.normalized();
+
+  if (planning_distance > planning_horizon_m_) {
+    goal_point.position_W =
+        start_point.position_W + planning_horizon_m_ * direction_to_waypoint;
+    planning_distance = planning_horizon_m_;
+  }
+
+  // Try to find an intermediate goal to go to if the edge of the planning
+  // horizon is occupied.
+  bool goal_found = true;
+  if (getMapDistance(goal_point.position_W) < constraints_.robot_radius) {
+    const double step_size = esdf_map_->voxel_size();
+    goal_found =
+        findIntermediateGoal(start_point, goal_point, step_size, &goal_point);
+  }
+
+  if (!goal_found) {
+    return false;
+  }
+
+  bool success =
+      getTrajectoryBetweenWaypoints(start_point, goal_point, trajectory);
+  return success;
+}
+
+bool VoxbloxLocoPlanner::getTrajectoryTowardGoalFromInitialTrajectory(
+    double start_time,
+    const mav_trajectory_generation::Trajectory& trajectory_in,
+    const mav_msgs::EigenTrajectoryPoint& goal,
+    mav_trajectory_generation::Trajectory* trajectory) {
+  mav_msgs::EigenTrajectoryPoint start;
+  start_time = std::min(trajectory->getMaxTime(), start_time);
+  bool success = sampleTrajectoryAtTime(trajectory_in, start_time, &start);
+  if (!success) {
+    return false;
+  }
+  return getTrajectoryTowardGoal(start, goal, trajectory);
+}
+
+bool VoxbloxLocoPlanner::findIntermediateGoal(
+    const mav_msgs::EigenTrajectoryPoint& start_point,
+    const mav_msgs::EigenTrajectoryPoint& goal_point, double step_size,
+    mav_msgs::EigenTrajectoryPoint* goal_out) const {
+  mav_msgs::EigenTrajectoryPoint new_goal = goal_point;
+
+  Eigen::Vector3d distance_to_waypoint =
+      goal_point.position_W - start_point.position_W;
+  double planning_distance = distance_to_waypoint.norm();
+  Eigen::Vector3d direction_to_waypoint = distance_to_waypoint.normalized();
+
+  bool success = false;
+  while (planning_distance >= 0.0) {
+    success = getNearestFreeSpaceToPoint(new_goal.position_W, step_size,
+                                         &new_goal.position_W);
+    if (success) {
+      break;
+    }
+    planning_distance -= step_size;
+    new_goal.position_W =
+        start_point.position_W + planning_distance * direction_to_waypoint;
+  }
+
+  if (success) {
+    *goal_out = new_goal;
+  }
+  return success;
+}
+
+bool VoxbloxLocoPlanner::getNearestFreeSpaceToPoint(
+    const Eigen::Vector3d& pos, double step_size,
+    Eigen::Vector3d* new_pos) const {
+  CHECK(esdf_map_);
+  Eigen::Vector3d final_pos = pos;
+  double distance = 0.0;
+  Eigen::Vector3d gradient = Eigen::Vector3d::Zero();
+
+  const size_t kMaxIter = 20;
+  for (size_t i = 0; i < kMaxIter; i++) {
+    double distance = getMapDistanceAndGradient(final_pos, &gradient);
+    if (distance >= constraints_.robot_radius) {
+      *new_pos = final_pos;
+      return true;
+    }
+
+    if (gradient.norm() > 1e-6) {
+      final_pos += gradient.normalized() * step_size;
+    }
+  }
+  return false;
 }
 
 }  // namespace mav_planning


### PR DESCRIPTION
In order of decreasing relevance/importance:
- Wrote **mav_local_planner**
  - This node takes in the current odometry of the MAV and intelligently plans toward waypoints or series of waypoints.
  - If the waypoint or waypoints are in known free space, and a valid path exists, uses a path smoother as specified by the "smoother_name" ros param.
  - If not, then (if "avoid_collisions" param is on), tries to navigate using **voxblox_loco_planner** toward the waypoint until it is reached or a max number of failures is encountered.
  - Inputs: single waypoint (`geometry_msgs/PoseStamped`), multiple waypoints (`geometry_msgs/PoseArray`) (and connections to ESDF maps from a separate voxblox node).
  - Outputs: 100 Hz sampled trajectory to controller.
- Wrote **voxblox_loco_planner**
  - Wrapper for the underlying loco optimization to allow random restarts, exploration of unknown space, etc.
  - Still to do: finding intermediate goals intelligently (ICRA 2018 paper).
- Set up gazebo simulation using [rotors_simulator](https://github.com/ethz-asl/rotors_simulator) to test out local planner
  - Runs mapping and planning at 4 Hz in simulation based on VI sensor depth. :) (screenshots below)
  - Introduces a hand-made gazebo world called maze_house, which is a house that is a maze.
- Wrote scaffolding for local benchmarking
  - Will be used to re-create or repeat experiments in ICRA 2018 paper, currently just scaffolding.

![gazebo_local_sim](https://user-images.githubusercontent.com/5616392/48097684-d5469580-e21a-11e8-8fe3-6ad024b18bf8.png)
![rviz_local_sim1](https://user-images.githubusercontent.com/5616392/48097689-d8418600-e21a-11e8-9d8b-7b5194b5c302.png)