### PR TITLE
Remove explicit find_package of OMPL

### DIFF
--- a/voxblox_rrt_planner/CMakeLists.txt
+++ b/voxblox_rrt_planner/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(voxblox_rrt_planner)
 
 find_package(catkin_simple REQUIRED)
-find_package(OMPL REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
 add_definitions(-std=c++11)


### PR DESCRIPTION
catkin_simple(ALL_DEPS_REQUIRED) will call find_package(...) 
on each dependency with the REQUIRED option.
Also, with find_package(OMPL REQUIRED) written explicitly, it
might not find OMPL installed via apt-get install ros-version-ompl