### PR TITLE
Fixes std::accumulate.

### DIFF
--- a/mav_planning_common/src/visibility_resampling.cpp
+++ b/mav_planning_common/src/visibility_resampling.cpp
@@ -1,3 +1,5 @@
+#include <numeric>
+
 #include <mav_trajectory_generation/vertex.h>
 
 #include "mav_planning_common/visibility_resampling.h"


### PR DESCRIPTION
Fixes
```
/home/rik/voliro_ws/src/mav_voxblox_planning/mav_planning_common/src/visibility_resampling.cpp:27:12: error: ‘accumulate’ is not a member of ‘std’
       std::accumulate(segment_times.begin(), segment_times.end(), 0.0);
```