### PR TITLE
Explicitly include OMPL directories.

### DIFF
--- a/voxblox_rrt_planner/CMakeLists.txt
+++ b/voxblox_rrt_planner/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(voxblox_rrt_planner)
 
 find_package(catkin_simple REQUIRED)
-find_package(OMPL REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
 add_definitions(-std=c++11)
@@ -10,6 +9,7 @@ add_definitions(-std=c++11)
 #############
 # LIBRARIES #
 #############
+include_directories(${OMPL_INCLUDE_DIRS})
 cs_add_library(${PROJECT_NAME}
   src/voxblox_ompl_rrt.cpp
   src/voxblox_rrt_planner.cpp
@@ -28,4 +28,4 @@ target_link_libraries(voxblox_rrt_planner_node ${PROJECT_NAME})
 # EXPORT #
 ##########
 cs_install()
-cs_export(LIBRARIES ${OMPL_LIBRARIES})
+cs_export()


### PR DESCRIPTION
Changes the way OMPL is included. Catkin simple was having issues finding OMPL in ROS melodic. Maybe it's because OMPL is in that cascaded folder now /opt/ros/melodic/include/ompl-1.4/ompl/. 