### PR TITLE
Added configuration possibility howto treat unknown voxels.

### DIFF
--- a/voxblox_rrt_planner/include/voxblox_rrt_planner/ompl/mav_setup.h
+++ b/voxblox_rrt_planner/include/voxblox_rrt_planner/ompl/mav_setup.h
@@ -66,10 +66,11 @@ class MavSetup : public geometric::SimpleSetup {
   }
 
   void setTsdfVoxbloxCollisionChecking(
-      double robot_radius, voxblox::Layer<voxblox::TsdfVoxel>* tsdf_layer) {
+      double robot_radius, voxblox::Layer<voxblox::TsdfVoxel>* tsdf_layer, bool treat_unknown_as_occupied=false) {
     std::shared_ptr<TsdfVoxbloxValidityChecker> validity_checker(
         new TsdfVoxbloxValidityChecker(getSpaceInformation(), robot_radius,
                                        tsdf_layer));
+    validity_checker->setTreatUnknownAsOccupied(treat_unknown_as_occupied);
 
     setStateValidityChecker(base::StateValidityCheckerPtr(validity_checker));
     si_->setMotionValidator(
@@ -78,10 +79,11 @@ class MavSetup : public geometric::SimpleSetup {
   }
 
   void setEsdfVoxbloxCollisionChecking(
-      double robot_radius, voxblox::Layer<voxblox::EsdfVoxel>* esdf_layer) {
+      double robot_radius, voxblox::Layer<voxblox::EsdfVoxel>* esdf_layer, bool treat_unknown_as_occupied=false) {
     std::shared_ptr<EsdfVoxbloxValidityChecker> validity_checker(
         new EsdfVoxbloxValidityChecker(getSpaceInformation(), robot_radius,
                                        esdf_layer));
+    validity_checker->setTreatUnknownAsOccupied(treat_unknown_as_occupied);
 
     setStateValidityChecker(base::StateValidityCheckerPtr(validity_checker));
     si_->setMotionValidator(

--- a/voxblox_rrt_planner/include/voxblox_rrt_planner/ompl/ompl_voxblox.h
+++ b/voxblox_rrt_planner/include/voxblox_rrt_planner/ompl/ompl_voxblox.h
@@ -125,7 +125,13 @@ class EsdfVoxbloxValidityChecker
                              double robot_radius,
                              voxblox::Layer<voxblox::EsdfVoxel>* esdf_layer)
       : VoxbloxValidityChecker(space_info, robot_radius, esdf_layer),
-        interpolator_(esdf_layer) {}
+        interpolator_(esdf_layer),
+        treat_unknown_as_occupied_(false) {}
+
+  bool getTreatUnknownAsOccupied() const { return treat_unknown_as_occupied_; }
+  void setTreatUnknownAsOccupied(bool treat_unknown_as_occupied) {
+    treat_unknown_as_occupied_ = treat_unknown_as_occupied;
+  }
 
   virtual bool checkCollisionWithRobot(
       const Eigen::Vector3d& robot_position) const {
@@ -135,7 +141,7 @@ class EsdfVoxbloxValidityChecker
     bool success = interpolator_.getDistance(
         robot_position.cast<voxblox::FloatingPoint>(), &distance, interpolate);
     if (!success) {
-      return true;
+      return treat_unknown_as_occupied_;
     }
 
     return robot_radius_ >= distance;
@@ -146,7 +152,7 @@ class EsdfVoxbloxValidityChecker
     voxblox::EsdfVoxel* voxel = layer_->getVoxelPtrByGlobalIndex(global_index);
 
     if (voxel == nullptr) {
-      return true;
+      return treat_unknown_as_occupied_;
     }
     return robot_radius_ >= voxel->distance;
   }
@@ -154,6 +160,7 @@ class EsdfVoxbloxValidityChecker
  protected:
   // Interpolator for the layer.
   voxblox::Interpolator<voxblox::EsdfVoxel> interpolator_;
+  bool treat_unknown_as_occupied_;
 };
 
 // Motion validator that uses either of the validity checkers above to

--- a/voxblox_rrt_planner/include/voxblox_rrt_planner/voxblox_ompl_rrt.h
+++ b/voxblox_rrt_planner/include/voxblox_rrt_planner/voxblox_ompl_rrt.h
@@ -85,6 +85,7 @@ class VoxbloxOmplRrt {
   double num_seconds_to_plan_;
   bool simplify_solution_;
   double robot_radius_;
+  bool treat_unkown_as_occupied_;
   bool verbose_;
 
   // Whether the planner is optimistic (true) or pessimistic (false) about

--- a/voxblox_rrt_planner/include/voxblox_rrt_planner/voxblox_rrt_planner.h
+++ b/voxblox_rrt_planner/include/voxblox_rrt_planner/voxblox_rrt_planner.h
@@ -82,6 +82,7 @@ class VoxbloxRrtPlanner {
   std::string frame_id_;
   bool visualize_;
   bool do_smoothing_;
+  double default_esdf_value_;
 
   // Robot parameters -- v max, a max, radius, etc.
   PhysicalConstraints constraints_;

--- a/voxblox_rrt_planner/src/voxblox_ompl_rrt.cpp
+++ b/voxblox_rrt_planner/src/voxblox_ompl_rrt.cpp
@@ -10,12 +10,14 @@ VoxbloxOmplRrt::VoxbloxOmplRrt(const ros::NodeHandle& nh,
       num_seconds_to_plan_(2.5),
       simplify_solution_(true),
       robot_radius_(1.0),
+      treat_unkown_as_occupied_(true),
       verbose_(false),
       optimistic_(true),
       trust_approx_solution_(false),
       lower_bound_(Eigen::Vector3d::Zero()),
       upper_bound_(Eigen::Vector3d::Zero()) {
   nh_private_.param("robot_radius", robot_radius_, robot_radius_);
+  nh_private_.param("treat_unkown_as_occupied", treat_unkown_as_occupied_, treat_unkown_as_occupied_);
   nh_private_.param("num_seconds_to_plan", num_seconds_to_plan_,
                     num_seconds_to_plan_);
   nh_private_.param("simplify_solution", simplify_solution_,
@@ -47,10 +49,10 @@ void VoxbloxOmplRrt::setEsdfLayer(
 void VoxbloxOmplRrt::setupProblem() {
   if (optimistic_) {
     CHECK_NOTNULL(tsdf_layer_);
-    problem_setup_.setTsdfVoxbloxCollisionChecking(robot_radius_, tsdf_layer_);
+    problem_setup_.setTsdfVoxbloxCollisionChecking(robot_radius_, tsdf_layer_, treat_unkown_as_occupied_);
   } else {
     CHECK_NOTNULL(esdf_layer_);
-    problem_setup_.setEsdfVoxbloxCollisionChecking(robot_radius_, esdf_layer_);
+    problem_setup_.setEsdfVoxbloxCollisionChecking(robot_radius_, esdf_layer_, treat_unkown_as_occupied_);
   }
   problem_setup_.setDefaultObjective();
   if (planner_type_ == kRrtConnect) {

--- a/voxblox_rrt_planner/src/voxblox_rrt_planner.cpp
+++ b/voxblox_rrt_planner/src/voxblox_rrt_planner.cpp
@@ -17,6 +17,7 @@ VoxbloxRrtPlanner::VoxbloxRrtPlanner(const ros::NodeHandle& nh,
       frame_id_("odom"),
       visualize_(true),
       do_smoothing_(true),
+      default_esdf_value_(0.0),
       last_trajectory_valid_(false),
       lower_bound_(Eigen::Vector3d::Zero()),
       upper_bound_(Eigen::Vector3d::Zero()),
@@ -29,6 +30,7 @@ VoxbloxRrtPlanner::VoxbloxRrtPlanner(const ros::NodeHandle& nh,
   nh_private_.param("visualize", visualize_, visualize_);
   nh_private_.param("frame_id", frame_id_, frame_id_);
   nh_private_.param("do_smoothing", do_smoothing_, do_smoothing_);
+  nh_private_.param("default_esdf_value", default_esdf_value_, default_esdf_value_);
 
   path_marker_pub_ =
       nh_private_.advertise<visualization_msgs::MarkerArray>("path", 1, true);
@@ -335,12 +337,12 @@ bool VoxbloxRrtPlanner::checkPathForCollisions(
 double VoxbloxRrtPlanner::getMapDistance(
     const Eigen::Vector3d& position) const {
   if (!voxblox_server_.getEsdfMapPtr()) {
-    return 0.0;
+    return default_esdf_value_;
   }
-  double distance = 0.0;
+  double distance = default_esdf_value_;
   if (!voxblox_server_.getEsdfMapPtr()->getDistanceAtPosition(position,
                                                               &distance)) {
-    return 0.0;
+    return default_esdf_value_;
   }
   return distance;
 }


### PR DESCRIPTION
This pull request adds the possibility of configuring how to treat unknown voxels to the OMPL planners (voxblox_rrt_planner package). By default, the behavior of the package does not change (i.e. treating unknown voxels as occupied), but adds to possibility to configure the behavior by two new ros parameters:

- ~treat_unknown_as_occupied (default: false) Selects how unknown voxels are handeled in the collision check of the OMPL planners.
- ~default_esdf_value (default: 0.0) Specifies the default distance value for unknown voxels which is used in the start, goal and point validity check of the planner.